### PR TITLE
Add notebooks to tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ INSTALL_REQUIRES = [
 ]
 
 extras_require = {
-    'test': ['pytest', 'pytest-mpl'],
-    'develop': ['flake8', 'twine'],
+    'test': ['pytest', 'pytest-mpl', 'papermill~=1.0', 'nteract-scrapbook~=0.3'],
+    'develop': ['flake8', 'jupyter', 'twine'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,16 @@
+import sys
+import papermill as pm
+import pytest
+
+
+@pytest.fixture()
+def common_kwargs(tmpdir):
+    outputnb = tmpdir.join('output.ipynb')
+    return {
+        'output_path': str(outputnb),
+        'kernel_name': 'python{}'.format(sys.version_info.major),
+    }
+
+
+def test_examples(common_kwargs):
+    pm.execute_notebook('Examples.ipynb', **common_kwargs)


### PR DESCRIPTION
Use [papermill](https://github.com/nteract/papermill) to add testing of Jupyter notebooks.