### PR TITLE
Using packaging to deal with mpl version switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 - pytest --mpl
 
 install:
-- python -m pip install -q --upgrade pip setuptools wheel setuptools_scm
+- python -m pip install -q --upgrade pip packaging setuptools wheel setuptools_scm
 - python -m pip install -q --no-cache-dir -e .[complete]
 
 

--- a/mplhep/plot.py
+++ b/mplhep/plot.py
@@ -14,6 +14,7 @@ _mpl_up = version.parse(mpl.__version__) >= version.parse(_mpl_up_version)
 ########################################
 # Histogram plotter
 
+
 def histplot(h, bins, weights=None, yerr=None, variances=None,
              stack=False, density=False,
              histtype='step', label=None, edges=False, binticks=False,

--- a/mplhep/plot.py
+++ b/mplhep/plot.py
@@ -6,6 +6,10 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable, axes_size
 
 from .error_estimation import poisson_interval
 
+# mpl updated to new methods
+from packaging import version
+_mpl_up_version = '3.3.3'
+_mpl_up = version.parse(mpl.__version__) >= version.parse(_mpl_up_version)
 
 ########################################
 # Histogram plotter
@@ -20,12 +24,6 @@ def histplot(h, bins, weights=None, yerr=None, variances=None,
     else:
         if not isinstance(ax, plt.Axes):
             raise ValueError("ax must be a matplotlib Axes object")
-
-    # mpl updated to new methods
-    _mpl_up = np.prod([int(v) >= int(ref)
-                       for v, ref in zip(mpl.__version__.split('.')[:3],
-                                         [3, 3, 3])
-                       ]).astype(bool)
 
     # arg check
     if histtype != 'step':

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ INSTALL_REQUIRES = [
     'numpy>=1.16.0',
     'scipy>=1.1.0',
     'requests~=2.21',
+    'packaging',
 ]
 
 extras_require = {


### PR DESCRIPTION
Old code was brittle in the case of release candidates and other alphanumeric version indicators.
I ran into this problem in windows using python3.