### PR TITLE
feat: Use bumpversion to automate version updates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.0.25
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ INSTALL_REQUIRES = [
 
 extras_require = {
     'test': ['pytest', 'pytest-mpl', 'papermill~=1.0', 'nteract-scrapbook~=0.3'],
-    'develop': ['flake8', 'jupyter', 'twine'],
+    'develop': ['flake8', 'jupyter', 'bumpversion', 'twine'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
Use [`bumpversion`](https://github.com/peritus/bumpversion) to easily update the version number, make a commit, and a version tag from the command line.

For example, with this PR accepted to make a new patch release one would simply type at the command line

```
bumpversion patch
```

and the result would be

```diff
$ git show HEAD
commit 980945b1b0d66dc2760cfe2cddc98670f88f8672 (HEAD -> feat/use-bumpversion-to-automate-updates, tag: v0.0.26)
Author: Matthew Feickert <matthew.feickert@cern.ch>
Date:   Wed Jan 15 11:49:03 2020 -0600

    Bump version: 0.0.25 → 0.0.26

diff --git a/.bumpversion.cfg b/.bumpversion.cfg
index 593a501..ad1fe44 100644
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,7 @@
 [bumpversion]
-current_version = 0.0.25
+current_version = 0.0.26
 commit = True
 tag = True
 
 [bumpversion:file:setup.py]
+
diff --git a/setup.py b/setup.py
index 1993cca..e43a420 100644
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class PostInstallCommand(install):
     """
 
 
-__version__ = '0.0.25'
+__version__ = '0.0.26'^M
 
 setup(
     name='mplhep',
```

The same thing works with minor and major releases of course.

This is done in part of some PRs that I want to add to help make publishing easier (...eventually for all of Scikit-HEP). :)