### PR TITLE
Add LHCb style sheet

### DIFF
--- a/mplhep/__init__.py
+++ b/mplhep/__init__.py
@@ -5,6 +5,7 @@ import requests as req
 # Get helper functions
 from . import cms
 from . import atlas
+from . import lhcb
 from . import plot
 from . import label
 
@@ -49,7 +50,7 @@ font_list = fm.createFontList(font_files)
 fm.fontManager.ttflist.extend(font_list)
 
 # Log submodules
-__all__ = [cms, atlas, plot, style, tools, label,
+__all__ = [cms, atlas, lhcb, plot, style, tools, label,
            # Log plot functions
            'histplot',
            'hist2dplot',

--- a/mplhep/lhcb.py
+++ b/mplhep/lhcb.py
@@ -1,0 +1,26 @@
+# Log styles
+from . import styles_lhcb as style
+from . import label as label_base
+from . label import lumitext
+__all__ = [style, lumitext]
+
+
+# Experiment wrappers:
+def lhcbtext(text="", **kwargs):
+    return label_base._exptext("LHCb", text=text, italic=(False, False),
+                               fontsize=28, fontname="Times New Roman",
+                               loc=1, **kwargs)
+
+
+def lhcblabel(**kwargs):
+    return label_base._explabel(exp="LHCb", italic=(False, False),
+                                fontsize=28, fontname="Times New Roman",
+                                loc=1, **kwargs)
+
+
+def text(*args, **kwargs):
+    return lhcbtext(*args, **kwargs)
+
+
+def label(**kwargs):
+    return lhcblabel(**kwargs)

--- a/mplhep/stylelib/LHCb.mplstyle
+++ b/mplhep/stylelib/LHCb.mplstyle
@@ -1,0 +1,96 @@
+## LHCb-like style
+# based on the works of Elena Graverini, Kevin Dungs, Tim Head, Thomas Schietinger,
+#                       Andrew Powell, Chris Parkes and Niels Tuning
+#
+# Modified by: Andreas Weiden
+# Date:        2019-08-09
+#
+# Created by:  Kevin Dungs
+# Date:        2014-02-19
+#
+# The following lines should be used in your python script:
+#   plt.xlabel(..., ha='center', y=1)
+#   plt.ylabel(..., ha='right', x=1, y=1)
+#   plt.legend(loc='best')
+#   plt.minorticks_on()
+#
+# In order to add a proper "LHCb Simulation" text box, use:
+#   plt.text(x_BRNDC, y_BRNDC, 'LHCb Simulation', {'size': 28}, transform=ax.transAxes)
+
+# Plot properties
+axes.labelsize: 32
+axes.linewidth: 2
+axes.facecolor: white
+# Custom colors
+axes.prop_cycle: cycler('color', ["1f77b4", "ff7f0e", "2ca02c", "d62728", "9467bd", "8c564b", "e377c2", "7f7f7f", "bcbd22", "17becf"]) + cycler('marker', ['o', 's', 'D', '^', 'v', '<', '>', 'P', 'X', '*'])
+axes.formatter.min_exponent: 3
+
+
+# Figure properties
+figure.figsize: 12, 9
+figure.dpi:     100
+# Outer frame color
+figure.facecolor: white
+figure.autolayout: True
+
+# Set default font to Times New Roman
+font.family: serif
+font.serif:  Times New Roman
+font.size:   14
+font.weight: 400
+# Use LaTeX rendering by default
+# (overrides default font)
+text.usetex: True
+# Use the LaTeX version of Times New Roman
+text.latex.preamble: \usepackage{mathptmx}
+pgf.rcfonts: False
+
+# Draw the legend on a solid background
+legend.frameon:       True
+legend.fancybox:      False
+# Inherit the background color from the plot
+legend.facecolor:     inherit
+legend.numpoints:     1
+legend.labelspacing:  0.2
+legend.fontsize:      28
+legend.title_fontsize:28  # Python 3+ & matplotlib 3?+
+# Automatically choose the best location
+legend.loc:           best
+# Space between the handles and their labels
+legend.handletextpad: 0.75
+# Space between the borders of the plot and the legend
+legend.borderaxespad: 1.0
+legend.edgecolor: white
+
+# Lines settings
+lines.linewidth:       4
+lines.markeredgewidth: 0
+lines.markersize:      8
+
+# Saved figure settings
+savefig.bbox:       tight
+savefig.pad_inches: 0.1
+savefig.format:     pdf
+
+# Ticks settings
+xtick.major.size:  14
+xtick.minor.size:  7
+xtick.major.width: 2
+xtick.minor.width: 2
+xtick.major.pad:   10
+xtick.minor.pad:   10
+xtick.direction:   in
+xtick.labelsize:   30
+ytick.major.size:  14
+ytick.minor.size:  7
+ytick.major.width: 2
+ytick.minor.width: 2
+ytick.major.pad:   10
+ytick.minor.pad:   10
+ytick.direction:   in
+ytick.labelsize:   30
+
+# Legend frame border size
+# WARNING: this affects every patch object
+# (i.e. histograms and so on)
+patch.linewidth: 2

--- a/mplhep/styles_lhcb.py
+++ b/mplhep/styles_lhcb.py
@@ -1,0 +1,86 @@
+from cycler import cycler
+
+colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+          '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
+markers = ['o', 's', 'D', '^', 'v', '<', '>', 'P', 'X', '*']
+
+ROOT = {
+    # Plot properties
+    "axes.labelsize": 32,
+    "axes.linewidth": 2,
+    "axes.facecolor": "white",
+    # Custom colors
+    "axes.prop_cycle": cycler('color', colors) + cycler('marker', markers),
+    "axes.formatter.min_exponent": 3,
+    # Figure properties
+    "figure.figsize": (12, 9),
+    "figure.dpi": 100,
+    # Outer frame color
+    "figure.facecolor": "white",
+    "figure.autolayout": True,
+
+    # Set default font to Times New Roman
+    "font.family": "serif",
+    "font.serif": ["Times New Roman"],
+    "font.size": 14,
+    "font.weight": 400,
+
+    # Draw the legend on a solid background
+    "legend.frameon": True,
+    "legend.fancybox": False,
+    # Inherit the background color from the plot
+    "legend.facecolor": "inherit",
+    "legend.numpoints": 1,
+    "legend.labelspacing": 0.2,
+    "legend.fontsize": 28,
+    "legend.title_fontsize": 28,
+    # Automatically choose the best location
+    "legend.loc": "best",
+    # Space between the handles and their labels
+    "legend.handletextpad": 0.75,
+    # Space between the borders of the plot and the legend
+    "legend.borderaxespad": 1.0,
+    "legend.edgecolor": "white",
+
+    # Lines settings
+    "lines.linewidth": 4,
+    "lines.markeredgewidth": 0,
+    "lines.markersize": 8,
+
+    # Saved figure settings
+    "savefig.bbox": "tight",
+    "savefig.pad_inches": 0.1,
+    "savefig.format": "pdf",
+
+    # Ticks settings
+    "xtick.major.size": 14,
+    "xtick.minor.size": 7,
+    "xtick.major.width": 2,
+    "xtick.minor.width": 2,
+    "xtick.major.pad": 10,
+    "xtick.minor.pad": 10,
+    "xtick.direction": "in",
+    "xtick.labelsize": 30,
+    "ytick.major.size": 14,
+    "ytick.minor.size": 7,
+    "ytick.major.width": 2,
+    "ytick.minor.width": 2,
+    "ytick.major.pad": 10,
+    "ytick.minor.pad": 10,
+    "ytick.direction": "in",
+    "ytick.labelsize": 30,
+
+    # Legend frame border size
+    # WARNING: this affects every patch object
+    # (i.e. histograms and so on)
+    "patch.linewidth": 2,
+}
+
+ROOTTex = {
+    # Use LaTeX rendering by default
+    # (overrides default font)
+    "text.usetex": True,
+    # Use the LaTeX version of Times New Roman
+    "text.latex.preamble": r"\usepackage{mathptmx}",
+    "pgf.rcfonts": False
+}

--- a/mplhep/styles_lhcb.py
+++ b/mplhep/styles_lhcb.py
@@ -12,6 +12,7 @@ ROOT = {
     # Custom colors
     "axes.prop_cycle": cycler('color', colors) + cycler('marker', markers),
     "axes.formatter.min_exponent": 3,
+    "axes.unicode_minus": False,
     # Figure properties
     "figure.figsize": (12, 9),
     "figure.dpi": 100,


### PR DESCRIPTION
Here is a style-sheet that tries to replicate the plotting style used by the LHCb experiment.
It is not faithful in all regards (notably colours and markers), but comes quite close.

The option `legend.title_fontsize` only works in recent versions of `matplotlib` and throws a warning otherwise.
The style uses LaTex by default, with the Times New Roman font (if installed).

Not sure how much work it is to convert it to the Python version you have for ATLAS and CMS.