### PR TITLE
feat: MonkeyClass pyplot

### DIFF
--- a/mplhep/pyplot.py
+++ b/mplhep/pyplot.py
@@ -1,0 +1,31 @@
+import mplhep.plot as hep
+
+# To monkeyclass
+from matplotlib.pyplot import Axes
+
+
+# Add and overwrite axes methods
+class MonkeyAxes(Axes):
+    def histplot(self, *args, **kwargs):
+        return hep.histplot(*args, ax=self, **kwargs)
+
+    def hist2dplot(self, *args, **kwargs):
+        return hep.hist2dplot(*args, ax=self, **kwargs)
+
+    # def set_xlabel(self, *args, **kwargs):
+    #     if 'x' not in kwargs:
+    #         kwargs.update(x=1.0)
+    #     if 'ha' not in kwargs or 'horizontalalignment' not in kwargs:
+    #         kwargs.update(ha='right')
+    #     return Axes.set_xlabel(self, *args, **kwargs)
+
+
+# Add
+Axes.histplot = MonkeyAxes.histplot
+Axes.hist2dplot = MonkeyAxes.hist2dplot
+
+# Overwrite
+# Axes.set_xlabel = MonkeyAxes.set_xlabel
+
+# Import rest of pyplot
+from matplotlib.pyplot import * # noqa


### PR DESCRIPTION
Allows for a more seamless matplotlib-like experience. As well as "patching" some objects in the future like `set_xlabel` before mpl catches up.
```
import mplhep.pyplot as plt
fig, ax = plt.subplots()
ax.histplot()
```
One downside is, this updates the Axes mpl class so while I don't know why you would need to, you cannot use `matplotlib.pyplot` at the same time. @HDembinski Do you know if this works for jax? If so I'll take a look at how to implement it.

Being able to do stuff like this main reason why I would prefer `histplot` not be renamed to `hist` but I'd be fine with `hist_plot` or some other non-conflicting name.