### PR TITLE
Errorbar: Use right labels

### DIFF
--- a/mplhep/plot.py
+++ b/mplhep/plot.py
@@ -312,7 +312,7 @@ def histplot(
                     h[i],
                     yerr=_yerr[i],
                     linestyle="none",
-                    label=_labels[0],
+                    label=_labels[i],
                     **_chunked_kwargs[i]
                 )
 


### PR DESCRIPTION
This is a tiny fix to plotting in "errorbar" mode to ensure that the right labels are used in the legend.