### PR TITLE
Include LICENSE in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include mplhep/.VERSION
 include mplhep/stylelib/*.mplstyle
 recursive-include mplhep/fonts/ *
+include LICENSE


### PR DESCRIPTION
Technically this is a requirement of the MIT licence and conda-forge is strict about licence compliance.