### PR TITLE
fix: don't ignore binwnorm

### DIFF
--- a/mplhep/plot.py
+++ b/mplhep/plot.py
@@ -185,7 +185,7 @@ def histplot(
             binnorms = binnorms[0]
         return binnorms
 
-    if density:
+    if density or binwnorm is not None:
         density_arr = get_density(h, density, binwnorm)
         if stack and densitymode == "stack":
             h = get_stack(h)


### PR DESCRIPTION
@AndreasAlbert Can you confirm this is expected behaviour?
```
import matplotlib.pyplot as plt
import mplhep as hep
import numpy as np
h, bins = np.histogram(np.random.normal(10,3,1000))

f, ax = plt.subplots()
hep.histplot(h, bins, label="Nominal")
hep.histplot(h, bins, binwnorm=1, label="1")
hep.histplot(h, bins, binwnorm=0.5, label="0.5")
plt.legend()
```

![image](https://user-images.githubusercontent.com/13226500/78274451-89cc1000-7510-11ea-809a-c7c125b37722.png)
