### PR TITLE
fix: Use 'line' over 'l' to placate flake8 E741

### DIFF
--- a/mplhep/plot.py
+++ b/mplhep/plot.py
@@ -484,7 +484,7 @@ def overlap(ax, bbox, get_vertices=False):
 
     # TODO Possibly other objects
 
-    vertices = np.concatenate([l.vertices for l in lines])
+    vertices = np.concatenate([line.vertices for line in lines])
     tvertices = [ax.transData.transform(v) for v in vertices]
 
     overlap = bbox.count_contains(tvertices) + bbox.count_overlaps(bboxes)


### PR DESCRIPTION
With the [release of `flake8` `v3.8.0` today](https://gitlab.com/pycqa/flake8/-/blob/master/docs/source/release-notes/3.8.0.rst) it seems that some rules are now [breaking CI](https://github.com/scikit-hep/mplhep/actions/runs/101991507). To placate [`flake8` E741](https://www.flake8rules.com/rules/E741.html) the use of the single letter variable `l` has been replaced with `line`. This is chosen over adding [E741](https://www.flake8rules.com/rules/E741.html) to the ignore list, as the rule does help check readability.