### PR TITLE
fix: support latest hist label name

### DIFF
--- a/mplhep/utils.py
+++ b/mplhep/utils.py
@@ -1,7 +1,10 @@
 def get_histogram_axes_title(axis):
     # type: (object) -> str
 
-    if hasattr(axis, "title"):
+    if hasattr(axis, "label"):
+        return axis.label
+    # Classic support for older hist, deprecated
+    elif hasattr(axis, "title"):
         return axis.title
     elif hasattr(axis, "name"):
         return axis.name


### PR DESCRIPTION
Hist renamed "title" to "label" following feedback. For now, support both.