### PR TITLE
docs: Update readme to use new mplhep.cms.label convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ plt.style.use({"font.sans-serif":'Comic Sans MS'})
 ## Experiment annotations
 ```diff
 + plt.style.use(hep.cms.style.ROOT)
-+ ax = hep.cms.cmslabel(data=False, paper=False, year='2017', ax=ax)
++ ax = hep.cms.label(data=False, paper=False, year='2017', ax=ax)
 ```
 <p float="center">
   <img src="img/style1.png" width="400" />


### PR DESCRIPTION
Really small change, as support for hep.cms.cmslabel has been dropped, but it appears as an example in the readme.