### PR TITLE
feat: Add mplhep.set_style API to set experiment style

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ hep.set_style({"font.sans-serif":'Comic Sans MS'})
 ```
 
 #### Styling with LaTeX
-- `hep.set_style("CMStex")` - Use LaTeX to produce all text labels
+- `hep.set_style("CMSTex")` - Use LaTeX to produce all text labels
 - Requires having the full tex-live distro
 - True Helvetica
 - Use sansmath as the math font

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ hep.hist2dplot(H, xbins, ybins)
 
 ### Other styles:
 - `hep.set_style("fira")` - use Fira Sans
-- `hep.set_style(style.firamath)` - use Fira Math
+- `hep.set_style("firamath")` - use Fira Math
 
 #### Styles can be chained:
-- e.g. `hep.set_style(["CMS", mplhep.style.fira, mplhep.style.firamath])`
+- e.g. `hep.set_style(["CMS", "fira", "firamath"])`
 - reappearing `rcParams` get overwritten silently
 
 #### Styles can be modified on the fly

--- a/README.md
+++ b/README.md
@@ -35,17 +35,24 @@ pip install mplhep
 ### Styling
 
 ```python
+import mplhep as hep
+hep.set_style(hep.style.ROOT) # For now ROOT defaults to CMS
+# Or choose one of the experiment styles
+hep.set_style(hep.style.CMS)
+# or
+hep.set_style("ATLAS") # string aliases work too
+# or
+hep.set_style("LHCb")
+# or
+hep.set_style("ALICE")
+```
+
+The style can be set directly from the `matplotlib` API as well
+
+```python
 import matplotlib.pyplot as plt
 import mplhep as hep
-plt.style.use(hep.style.ROOT) # For now ROOT defaults to CMS
-# Or choose one of the experiment styles
-plt.style.use(hep.style.CMS)
-# or
-plt.style.use(hep.style.ATLAS)
-# or
-plt.style.use(hep.style.LHCb)
-# or
-plt.style.use(hep.style.ALICE)
+plt.style.use(hep.style.ROOT)
 ```
 
 Experiment specific style are also available. **If the default styles are not what you need, I'd be happy to merge in new styles or modify the current ones.**
@@ -81,22 +88,22 @@ hep.hist2dplot(H, xbins, ybins)
 # More Information
 
 ### Other styles:
-- `plt.style.use(mplhep.style.fira)` - use Fira Sans
-- `plt.style.use(style.firamath)` - use Fira Math
+- `hep.set_style("fira")` - use Fira Sans
+- `hep.set_style(style.firamath)` - use Fira Math
 
 #### Styles can be chained:
-- e.g. `plt.style.use([mplhep.style.CMS, mplhep.style.fira, mplhep.style.firamath])`
-- reappearing rcParams get overwritten silently
+- e.g. `hep.set_style(["CMS", mplhep.style.fira, mplhep.style.firamath])`
+- reappearing `rcParams` get overwritten silently
 
 #### Styles can be modified on the fly
-- Since styles are dictionaries and they can be chained/overwritten they can be easiely modified on the fly. e.g.
+- Since styles are dictionaries and they can be chained/overwritten they can be easily modified on the fly. e.g.
 ```
-plt.style.use(mplhep.style.CMS)
-plt.style.use({"font.sans-serif":'Comic Sans MS'})
+hep.set_style("CMS")
+hep.set_style({"font.sans-serif":'Comic Sans MS'})
 ```
 
 #### Styling with LaTeX
-- `plt.style.use(mplhep.style.CMStex)` - Use LaTeX to produce all text labels
+- `hep.set_style("CMStex")` - Use LaTeX to produce all text labels
 - Requires having the full tex-live distro
 - True Helvetica
 - Use sansmath as the math font

--- a/src/mplhep/__init__.py
+++ b/src/mplhep/__init__.py
@@ -15,6 +15,7 @@ from ._tools import Config
 
 # Get styles directly, also available within experiment helpers.
 from . import styles as style
+from .styles import set_style
 
 from .plot import (
     histplot,

--- a/src/mplhep/styles.py
+++ b/src/mplhep/styles.py
@@ -8,7 +8,7 @@ from .styles_alice import ALICE
 from .styles_lhcb import LHCb, LHCbTex
 
 
-def set_style(style):
+def set_style(styles):
     """
     Set the experiment specific plotting style
 
@@ -20,10 +20,15 @@ def set_style(style):
 
     Parameters
     ----------
-        style (`str` or `mplhep.style` `dict`): The experiment sytle
+        styles (`str` or `mplhep.style` `dict`): The experiment style
     """
-    if isinstance(style, dict):
-        # passed in experiment mplhep.style dict
-        plt_style.use(style)
-    else:
-        plt_style.use(getattr(sys.modules[__name__], f"{style}"))
+    if not isinstance(styles, list):
+        styles = [styles]
+
+    # passed in experiment mplhep.style dict or str alias
+    styles = [
+        style if isinstance(style, dict) else getattr(sys.modules[__name__], f"{style}")
+        for style in styles
+    ]
+
+    plt_style.use(styles)

--- a/src/mplhep/styles.py
+++ b/src/mplhep/styles.py
@@ -1,5 +1,29 @@
+import sys
+from matplotlib.pyplot import style as plt_style
+
 # Short cut to all styles
 from .styles_cms import CMS, CMSTex, ROOT, ROOTTex, firamath, fabiola
 from .styles_atlas import ATLAS
 from .styles_alice import ALICE
 from .styles_lhcb import LHCb, LHCbTex
+
+
+def set_style(style):
+    """
+    Set the experiment specific plotting style
+
+    Example:
+
+        >>> import mplhep as hep
+        >>> hep.set_style("ATLAS")
+        >>> hep.set_style(mplhep.style.CMS)
+
+    Parameters
+    ----------
+        style (`str` or `mplhep.style` `dict`): The experiment sytle
+    """
+    if isinstance(style, dict):
+        # passed in experiment mplhep.style dict
+        plt_style.use(style)
+    else:
+        plt_style.use(getattr(sys.modules[__name__], f"{style}"))

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -77,19 +77,19 @@ def test_style_lhcb():
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
 @check_figures_equal(extensions=["pdf"])
 @pytest.mark.parametrize(
-    "style",
+    "mplhep_style",
     [hep.style.ALICE, hep.style.ATLAS, hep.style.CMS, hep.style.LHCb, hep.style.ROOT],
     ids=["ALICE", "ATLAS", "CMS", "LHCb", "ROOT"],
 )
-def test_set_style(fig_test, fig_ref, style):
+def test_set_style(fig_test, fig_ref, mplhep_style):
     plt.rcParams.update(plt.rcParamsDefault)
 
     hep.rcParams.clear()
-    plt.style.use(style)
+    plt.style.use(mplhep_style)
     fig_ref.subplots()
 
     hep.rcParams.clear()
-    hep.set_style(style)
+    hep.set_style(mplhep_style)
     fig_test.subplots()
 
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -87,11 +87,11 @@ def test_set_style(fig_test, fig_ref):
 
     hep.rcParams.clear()
     plt.style.use(hep.style.CMS)
-    ref_ax = fig_ref.subplots()
+    fig_ref.subplots()
 
     hep.rcParams.clear()
     hep.set_style(hep.style.CMS)
-    test_ax = fig_test.subplots()
+    fig_test.subplots()
 
 
 @check_figures_equal(extensions=["pdf"])
@@ -101,11 +101,11 @@ def test_set_style_str_alias(fig_test, fig_ref):
 
     hep.rcParams.clear()
     plt.style.use(hep.style.ATLAS)
-    ref_ax = fig_ref.subplots()
+    fig_ref.subplots()
 
     hep.rcParams.clear()
     hep.set_style("ATLAS")
-    test_ax = fig_test.subplots()
+    fig_test.subplots()
 
 
 @check_figures_equal(extensions=["pdf"])
@@ -115,11 +115,11 @@ def test_set_style_self_consistent(fig_test, fig_ref):
 
     hep.rcParams.clear()
     hep.set_style(hep.style.LHCb)
-    ref_ax = fig_ref.subplots()
+    fig_ref.subplots()
 
     hep.rcParams.clear()
     hep.set_style("LHCb")
-    test_ax = fig_test.subplots()
+    fig_test.subplots()
 
 
 @check_figures_equal(extensions=["pdf"])
@@ -129,11 +129,11 @@ def test_set_style_style_list(fig_test, fig_ref):
 
     hep.rcParams.clear()
     plt.style.use([hep.style.CMS, {"font.sans-serif": "Comic Sans MS"}])
-    ref_ax = fig_ref.subplots()
+    fig_ref.subplots()
 
     hep.rcParams.clear()
     hep.set_style(["CMS", {"font.sans-serif": "Comic Sans MS"}])
-    test_ax = fig_test.subplots()
+    fig_test.subplots()
 
 
 @pytest.mark.mpl_image_compare(style="default")

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -74,6 +74,68 @@ def test_style_lhcb():
     return fig
 
 
+@check_figures_equal(extensions=["pdf"])
+# @pytest.mark.parametrize(
+#     "experiment_style",
+#     [hep.style.ALICE, hep.style.ATLAS, hep.style.CMS, hep.style.LHCb, hep.style.ROOT,],
+#     ids=["ALICE", "ATLAS", "CMS", "LHCb", "ROOT"],
+# )
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
+# def test_set_style(experiment_style, fig_test, fig_ref):
+def test_set_style(fig_test, fig_ref):
+    plt.rcParams.update(plt.rcParamsDefault)
+
+    hep.rcParams.clear()
+    plt.style.use(hep.style.CMS)
+    ref_ax = fig_ref.subplots()
+
+    hep.rcParams.clear()
+    hep.set_style(hep.style.CMS)
+    test_ax = fig_test.subplots()
+
+
+@check_figures_equal(extensions=["pdf"])
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
+def test_set_style_str_alias(fig_test, fig_ref):
+    plt.rcParams.update(plt.rcParamsDefault)
+
+    hep.rcParams.clear()
+    plt.style.use(hep.style.ATLAS)
+    ref_ax = fig_ref.subplots()
+
+    hep.rcParams.clear()
+    hep.set_style("ATLAS")
+    test_ax = fig_test.subplots()
+
+
+@check_figures_equal(extensions=["pdf"])
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
+def test_set_style_self_consistent(fig_test, fig_ref):
+    plt.rcParams.update(plt.rcParamsDefault)
+
+    hep.rcParams.clear()
+    hep.set_style(hep.style.LHCb)
+    ref_ax = fig_ref.subplots()
+
+    hep.rcParams.clear()
+    hep.set_style("LHCb")
+    test_ax = fig_test.subplots()
+
+
+@check_figures_equal(extensions=["pdf"])
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
+def test_set_style_style_list(fig_test, fig_ref):
+    plt.rcParams.update(plt.rcParamsDefault)
+
+    hep.rcParams.clear()
+    plt.style.use([hep.style.CMS, {"font.sans-serif": "Comic Sans MS"}])
+    ref_ax = fig_ref.subplots()
+
+    hep.rcParams.clear()
+    hep.set_style(["CMS", {"font.sans-serif": "Comic Sans MS"}])
+    test_ax = fig_test.subplots()
+
+
 @pytest.mark.mpl_image_compare(style="default")
 def test_label_loc():
     fig, axs = plt.subplots(1, 4, figsize=(16, 4))

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -78,7 +78,7 @@ def test_style_lhcb():
 @check_figures_equal(extensions=["pdf"])
 @pytest.mark.parametrize(
     "style",
-    [hep.style.ALICE, hep.style.ATLAS, hep.style.CMS, hep.style.LHCb, hep.style.ROOT,],
+    [hep.style.ALICE, hep.style.ATLAS, hep.style.CMS, hep.style.LHCb, hep.style.ROOT],
     ids=["ALICE", "ATLAS", "CMS", "LHCb", "ROOT"],
 )
 def test_set_style(fig_test, fig_ref, style):

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -74,65 +74,97 @@ def test_style_lhcb():
     return fig
 
 
-@check_figures_equal(extensions=["pdf"])
-# @pytest.mark.parametrize(
-#     "experiment_style",
-#     [hep.style.ALICE, hep.style.ATLAS, hep.style.CMS, hep.style.LHCb, hep.style.ROOT,],
-#     ids=["ALICE", "ATLAS", "CMS", "LHCb", "ROOT"],
-# )
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
-# def test_set_style(experiment_style, fig_test, fig_ref):
-def test_set_style(fig_test, fig_ref):
+@check_figures_equal(extensions=["pdf"])
+@pytest.mark.parametrize(
+    "style",
+    [hep.style.ALICE, hep.style.ATLAS, hep.style.CMS, hep.style.LHCb, hep.style.ROOT,],
+    ids=["ALICE", "ATLAS", "CMS", "LHCb", "ROOT"],
+)
+def test_set_style(fig_test, fig_ref, style):
     plt.rcParams.update(plt.rcParamsDefault)
 
     hep.rcParams.clear()
-    plt.style.use(hep.style.CMS)
+    plt.style.use(style)
     fig_ref.subplots()
 
     hep.rcParams.clear()
-    hep.set_style(hep.style.CMS)
+    hep.set_style(style)
     fig_test.subplots()
 
 
-@check_figures_equal(extensions=["pdf"])
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
-def test_set_style_str_alias(fig_test, fig_ref):
+@check_figures_equal(extensions=["pdf"])
+@pytest.mark.parametrize(
+    "mplhep_style, str_alias",
+    [
+        (hep.style.ALICE, "ALICE"),
+        (hep.style.ATLAS, "ATLAS"),
+        (hep.style.CMS, "CMS"),
+        (hep.style.LHCb, "LHCb"),
+        (hep.style.ROOT, "ROOT"),
+    ],
+    ids=["ALICE", "ATLAS", "CMS", "LHCb", "ROOT"],
+)
+def test_set_style_str_alias(fig_test, fig_ref, mplhep_style, str_alias):
     plt.rcParams.update(plt.rcParamsDefault)
 
     hep.rcParams.clear()
-    plt.style.use(hep.style.ATLAS)
+    plt.style.use(mplhep_style)
     fig_ref.subplots()
 
     hep.rcParams.clear()
-    hep.set_style("ATLAS")
+    hep.set_style(str_alias)
     fig_test.subplots()
 
 
-@check_figures_equal(extensions=["pdf"])
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
-def test_set_style_self_consistent(fig_test, fig_ref):
+@check_figures_equal(extensions=["pdf"])
+@pytest.mark.parametrize(
+    "mplhep_style, str_alias",
+    [
+        (hep.style.ALICE, "ALICE"),
+        (hep.style.ATLAS, "ATLAS"),
+        (hep.style.CMS, "CMS"),
+        (hep.style.LHCb, "LHCb"),
+        (hep.style.ROOT, "ROOT"),
+    ],
+    ids=["ALICE", "ATLAS", "CMS", "LHCb", "ROOT"],
+)
+def test_set_style_self_consistent(fig_test, fig_ref, mplhep_style, str_alias):
     plt.rcParams.update(plt.rcParamsDefault)
 
     hep.rcParams.clear()
-    hep.set_style(hep.style.LHCb)
+    hep.set_style(mplhep_style)
     fig_ref.subplots()
 
     hep.rcParams.clear()
-    hep.set_style("LHCb")
+    hep.set_style(str_alias)
     fig_test.subplots()
 
 
-@check_figures_equal(extensions=["pdf"])
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
-def test_set_style_style_list(fig_test, fig_ref):
+@check_figures_equal(extensions=["pdf"])
+@pytest.mark.parametrize(
+    "mplhep_style, str_alias",
+    [
+        (hep.style.ALICE, "ALICE"),
+        (hep.style.ATLAS, "ATLAS"),
+        (hep.style.CMS, "CMS"),
+        (hep.style.LHCb, "LHCb"),
+        (hep.style.ROOT, "ROOT"),
+    ],
+    ids=["ALICE", "ATLAS", "CMS", "LHCb", "ROOT"],
+)
+def test_set_style_style_list(fig_test, fig_ref, mplhep_style, str_alias):
     plt.rcParams.update(plt.rcParamsDefault)
 
     hep.rcParams.clear()
-    plt.style.use([hep.style.CMS, {"font.sans-serif": "Comic Sans MS"}])
+    plt.style.use([mplhep_style, {"font.sans-serif": "Comic Sans MS"}])
     fig_ref.subplots()
 
     hep.rcParams.clear()
-    hep.set_style(["CMS", {"font.sans-serif": "Comic Sans MS"}])
+    hep.set_style([str_alias, {"font.sans-serif": "Comic Sans MS"}])
     fig_test.subplots()
 
 


### PR DESCRIPTION
Resolves #213 

Allows for the following API

```python
import mplhep
mplhep.set_style("ATLAS") # string alias
mplhep.set_style(mplhep.style.CMS) # style dict
mplhep.set_style(["ATLAS", {"font.sans-serif": ["Tex Gyre Heros"]}]) # Still allow for lists of styles
```

**Squash and merge commit message**

```
* Add convince wrapper function mplhep.set_style to set experiment style
* Add tests of set_style API
* Update README to advocate for this API
```