### PR TITLE
chore: disallow py35

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=3.5
+python_requires = >=3.6
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
It was still 3.5 minimum version but the docs etc say 3.6+