### PR TITLE
fix: add LHCb2 errorbar plot style finalized

### DIFF
--- a/src/mplhep/styles/lhcb.py
+++ b/src/mplhep/styles/lhcb.py
@@ -129,6 +129,8 @@ LHCb2 = {
     "axes.prop_cycle": cycler("color", colors2),
     "axes.formatter.min_exponent": 3,
     "axes.titlesize": 28,
+    # Errorbar properties
+    "errorbar.capsize": 2.5,
     # Figure properties
     "figure.figsize": (12, 9),
     "figure.dpi": 300,
@@ -156,9 +158,10 @@ LHCb2 = {
     # Space between the borders of the plot and the legend
     "legend.borderaxespad": 1.0,
     # Lines settings
-    "lines.linewidth": 3.5,
-    "lines.markeredgewidth": 0,
-    "lines.markersize": 8,
+    "lines.linewidth": 3.3,
+    "lines.markeredgewidth": 1.5,
+    "lines.markersize": 17,
+    "lines.elinewidth": 1.8,
     # Saved figure settings
     "savefig.bbox": "tight",
     "savefig.pad_inches": 0.3,

--- a/src/mplhep/styles/lhcb.py
+++ b/src/mplhep/styles/lhcb.py
@@ -160,8 +160,8 @@ LHCb2 = {
     # Lines settings
     "lines.linewidth": 3.3,
     "lines.markeredgewidth": 1.5,
-    "lines.markersize": 17,
-    "lines.elinewidth": 1.8,
+    "lines.markersize": 16,
+    "lines.elinewidth": 1.5,
     # Saved figure settings
     "savefig.bbox": "tight",
     "savefig.pad_inches": 0.3,


### PR DESCRIPTION
I've added a small update (sorry, that glitched before) which was somewhat hidden due to a possible "bug" (or feature?) in histplot. This settings would give nice errorbar plots (in LHCb-style).

The comparison only works by explicitly giving the params as kwargs, not all are used from the style, see #225 

Comparison: old (top) vs new (bottom)

![image](https://user-images.githubusercontent.com/17454848/98826268-c6140700-2435-11eb-8a86-fdad80fdc904.png)


![image](https://user-images.githubusercontent.com/17454848/98826035-80efd500-2435-11eb-9bc7-8eb812a0f121.png)
