### PR TITLE
fix: add mathtext.cal setting to satisfy warnings

### DIFF
--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -93,6 +93,7 @@ ATLAS = {
     "mathtext.sf": "TeX Gyre Heros",
     "mathtext.it": "TeX Gyre Heros:italic",
     "mathtext.tt": "TeX Gyre Heros",
+    "mathtext.cal": "TeX Gyre Heros",
     "mathtext.default": "regular",
     "mathtext.fontset": "custom",
 }

--- a/src/mplhep/styles/cms.py
+++ b/src/mplhep/styles/cms.py
@@ -14,6 +14,7 @@ CMS = {
     "mathtext.sf": "TeX Gyre Heros",
     "mathtext.it": "TeX Gyre Heros:italic",
     "mathtext.tt": "TeX Gyre Heros",
+    "mathtext.cal": "TeX Gyre Heros",
     "mathtext.default": "regular",
     "figure.figsize": (10.0, 10.0),
     "font.size": 26,


### PR DESCRIPTION
Closes #240 @matthewfeickert @kratsg.

I didn't go for 
```
"mathtext.cal": "DejaVu Math TeX Gyre",
```
in the end because it doesn't seem to be shipped with mpl and it doesn't really matter imo.

ALICE and LHCb styles are not affected by this because they don't set `mathtext = custom`