### PR TITLE
ci: drop pre-commit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,6 @@ on:
   - cron:  '1 0 * * *'
 
 jobs:
-  linter:
-    runs-on: ubuntu-latest
-    name: pre-commit (linter)
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
 
   test:
     name: "🐍 ${{ matrix.python-version }} • ${{ matrix.runs-on }}"


### PR DESCRIPTION
Failed due to cache issue - we already use pre-commit.ci here, so let's just use that, it's faster and can auto-correct in some cases.