### PR TITLE
fix: adjust .yscale() for log axis

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -604,8 +604,13 @@ def yscale_legend(ax=None):
     if ax is None:
         ax = plt.gca()
 
+    if ax.get_yscale() == "log":
+        scale_factor = 10**(1.05)
+    else:
+        scale_factor = 1.05
+
     while overlap(ax, _draw_leg_bbox(ax)) > 0:
-        ax.set_ylim(ax.get_ylim()[0], ax.get_ylim()[-1] * 1.05)
+        ax.set_ylim(ax.get_ylim()[0], ax.get_ylim()[-1] * scale_factor)
         ax.figure.canvas.draw()
     return ax
 

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -605,7 +605,7 @@ def yscale_legend(ax=None):
         ax = plt.gca()
 
     if ax.get_yscale() == "log":
-        scale_factor = 10**(1.05)
+        scale_factor = 10 ** (1.05)
     else:
         scale_factor = 1.05
 


### PR DESCRIPTION
1.05 is too small a number if the y axis is set to log. To get the equivalent effect, the y axis needs to be scaled up by 10**(1.05). I check if the y axis is log and rewrite the scale number