### PR TITLE
feat: get fonts by download, don't package them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Package specific
+src/mplhep/fonts/downloaded/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include src/mplhep/.VERSION
-include src/mplhep/stylelib/*.mplstyle
-recursive-include src/mplhep/fonts/ *
+recursive-include src/mplhep/fonts/LICENSE*
 include LICENSE

--- a/src/mplhep/__init__.py
+++ b/src/mplhep/__init__.py
@@ -11,7 +11,7 @@ from . import alice
 from . import plot
 from . import label
 
-from ._tools import Config
+from ._tools import Config, FontLoader
 
 # Get styles directly, also available within experiment helpers.
 from . import styles as style
@@ -57,6 +57,64 @@ with open(os.path.join(_base_dir, ".VERSION")) as version_file:
 # Make package fonts available to matplotlib
 if version.parse(mpl.__version__) >= version.parse("3.2"):
     # mpl 3.2 and up
+    html_font_path = "https://github.com/scikit-hep/mplhep/raw/master/src/mplhep/fonts/"
+    FontLoader(
+        html_font_path + "texgyreheros/texgyreheros-bolditalic.otf", persist=True
+    ).prop
+    FontLoader(
+        html_font_path + "texgyreheros/texgyreheros-italic.otf", persist=True
+    ).prop
+    FontLoader(
+        html_font_path + "texgyreheros/texgyreheros-regular.otf", persist=True
+    ).prop
+    FontLoader(
+        html_font_path + "texgyreheros/texgyreheroscn-bold.otf", persist=True
+    ).prop
+    FontLoader(
+        html_font_path + "texgyreheros/texgyreheroscn-bolditalic.otf", persist=True
+    ).prop
+    FontLoader(
+        html_font_path + "texgyreheros/texgyreheroscn-italic.otf", persist=True
+    ).prop
+    FontLoader(html_font_path + "firasans/FiraMono-Bold.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraMono-Medium.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraMono-Regular.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-Black.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-BlackItalic.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-Bold.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-BoldItalic.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-ExtraBold.ttf", persist=True).prop
+    FontLoader(
+        html_font_path + "firasans/FiraSans-ExtraBoldItalic.ttf", persist=True
+    ).prop
+    FontLoader(html_font_path + "firasans/FiraSans-ExtraLight.ttf", persist=True).prop
+    FontLoader(
+        html_font_path + "firasans/FiraSans-ExtraLightItalic.ttf", persist=True
+    ).prop
+    FontLoader(html_font_path + "firasans/FiraSans-Italic.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-Light.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-LightItalic.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-Medium.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-MediumItalic.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-Regular.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-SemiBold.ttf", persist=True).prop
+    FontLoader(
+        html_font_path + "firasans/FiraSans-SemiBoldItalic.ttf", persist=True
+    ).prop
+    FontLoader(html_font_path + "firasans/FiraSans-Thin.ttf", persist=True).prop
+    FontLoader(html_font_path + "firasans/FiraSans-ThinItalic.ttf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-Bold.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-Book.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-ExtraBold.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-ExtraLight.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-Heavy.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-Light.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-Medium.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-Regular.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-SemiBold.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-Thin.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-Ultra.otf", persist=True).prop
+    FontLoader(html_font_path + "firamath/FiraMath-UltraLight.otf", persist=True).prop
     path = os.path.abspath(__file__)
     font_path = "/".join(path.split("/")[:-1]) + "/fonts/"
     font_files = fm.findSystemFonts(fontpaths=font_path)

--- a/src/mplhep/_tools.py
+++ b/src/mplhep/_tools.py
@@ -1,4 +1,7 @@
+import os
 import argparse
+import matplotlib as mpl
+import matplotlib.font_manager as fm
 
 
 class Config(argparse.Namespace):
@@ -8,3 +11,72 @@ class Config(argparse.Namespace):
                 value.clear()
             else:
                 setattr(self, key, None)
+
+
+class FontLoader:
+    """Utility to load fun fonts from https://fonts.google.com/ for matplotlib.
+    Find a nice font at https://fonts.google.com/, and then get its corresponding URL
+    from https://github.com/google/fonts/
+    Use like:
+    fl = FontLoader()
+    fig, ax = plt.subplots()
+    ax.text("Good content.", fontproperties=fl.prop, size=60)
+
+    Adapted from https://github.com/ColCarroll/ridge_map
+    """
+
+    def __init__(
+        self,
+        github_url="https://github.com/google/fonts/blob/master/ofl/cinzel/static/Cinzel-Regular.ttf?raw=true",
+        persist=False,
+        filename=None,
+    ):
+        """
+        Lazily download a font.
+        Parameters
+        ----------
+        github_url : str
+            Can really be any .ttf file, but probably looks like
+            "https://github.com/google/fonts/blob/master/ofl/cinzel/Cinzel-Regular.ttf?raw=true"
+        """
+        self.github_url = github_url
+        self._prop = None
+        self._persist = persist
+        self._filename = filename
+
+    @property
+    def prop(self):
+        """Get matplotlib.font_manager.FontProperties object that sets the custom font."""
+        if self._prop is None:
+            if self._persist:
+                if self._filename is not None:
+                    file_name = self._filename
+                else:
+                    _file_name = self.github_url.split("/")[-1]
+                    if "ttf" in _file_name:
+                        file_name = _file_name[: _file_name.find("ttf")] + "ttf"
+                    elif "otf" in _file_name:
+                        file_name = _file_name[: _file_name.find("otf")] + "otf"
+                    else:
+                        raise ValueError("Unknown font extension")
+                path = os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), "fonts/downloaded"
+                )
+                file_path = os.path.join(path, file_name)
+                if os.path.exists(file_path):
+                    self._prop = fm.FontProperties(fname=file_path)
+                else:
+                    import requests
+
+                    r = requests.get(self.github_url, allow_redirects=True)
+                    with open(file_path, "wb") as temp_file:
+                        temp_file.write(r.content)
+                    self._prop = fm.FontProperties(fname=file_path)
+            else:
+                from urllib.request import urlopen
+                from tempfile import NamedTemporaryFile
+
+                with NamedTemporaryFile(delete=False, suffix=".ttf") as temp_file:  # type: ignore
+                    temp_file.write(urlopen(self.github_url).read())
+                    self._prop = fm.FontProperties(fname=temp_file.name)
+        return self._prop

--- a/src/mplhep/_tools.py
+++ b/src/mplhep/_tools.py
@@ -69,14 +69,14 @@ class FontLoader:
                     import requests
 
                     r = requests.get(self.github_url, allow_redirects=True)
-                    with open(file_path, "wb") as temp_file:
-                        temp_file.write(r.content)
+                    with open(file_path, "wb") as font_file:
+                        font_file.write(r.content)
                     self._prop = fm.FontProperties(fname=file_path)
             else:
                 from urllib.request import urlopen
                 from tempfile import NamedTemporaryFile
 
-                with NamedTemporaryFile(delete=False, suffix=".ttf") as temp_file:  # type: ignore
+                with NamedTemporaryFile(delete=False, suffix=".ttf") as temp_file:
                     temp_file.write(urlopen(self.github_url).read())
                     self._prop = fm.FontProperties(fname=temp_file.name)
         return self._prop

--- a/src/mplhep/tools.py
+++ b/src/mplhep/tools.py
@@ -1,35 +1,3 @@
 import os
 import matplotlib as mpl
 import mplhep._deprecate as deprecate
-
-
-@deprecate.deprecate(
-    "Hardcoded style sheets and fonts will be deprecated, let us know"
-    "if this is affection your workflow"
-)
-def hardcopy_styles():
-    path = os.path.abspath(__file__)
-    pkg_dir = "/" + "/".join(path.split("/")[:-1])
-    os.system(f"cp -r {pkg_dir}/stylelib/ " + os.path.join(mpl.get_configdir() + "/"))
-
-
-@deprecate.deprecate(
-    "Hardcoded style sheets and fonts will be deprecated, let us know"
-    "if this is affection your workflow"
-)
-def hardcopy_fonts():
-    path = os.path.abspath(__file__)
-    pkg_dir = "/" + "/".join(path.split("/")[:-1])
-    os.system(
-        f"cp -r {pkg_dir}/fonts/firasans/* "
-        + os.path.join(mpl.rcParams["datapath"] + "/fonts/ttf/")
-    )
-    os.system(
-        f"cp -r {pkg_dir}/fonts/firamath/* "
-        + os.path.join(mpl.rcParams["datapath"] + "/fonts/ttf/")
-    )
-    os.system(
-        f"cp -r {pkg_dir}/fonts/texgyreheros/* "
-        + os.path.join(mpl.rcParams["datapath"] + "/fonts/ttf/")
-    )
-    os.system("rm " + os.path.join(mpl.get_cachedir() + "/font*"))

--- a/src/mplhep/tools.py
+++ b/src/mplhep/tools.py
@@ -1,3 +1,0 @@
-import os
-import matplotlib as mpl
-import mplhep._deprecate as deprecate


### PR DESCRIPTION
@matthewfeickert first take on #241, let me know if you think there should be a better way to fetch the fonts than one by one. Unfortunately, there doesn't seem to be a unified way to fetch them from their original repositories, so we'll still have to host copies, but the pypi dists should be quite a bit lighter.

Actually, on second thought, this could lead to potential problems, if one for created an image/env on while having internet connection, but only tried to load it later when not connected to the internet.