### PR TITLE
docs: update figure numbers for arXiv:2004.02327

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ For now one has to set the style globally:
 Updating list of citations and use cases of `mplhep` in publications:
 
 - [Simultaneous Jet Energy and Mass Calibrations with Neural Networks](https://cds.cern.ch/record/2706189), ATLAS Collaboration, 2019
-- [Integration and Performance of New Technologies in the CMS Simulation](https://arxiv.org/abs/2004.02327), Kevin Pedro, 2020 (Fig 3,4)
+- [Integration and Performance of New Technologies in the CMS Simulation](https://arxiv.org/abs/2004.02327), Kevin Pedro, 2020 (Fig 5,6)
 - [GeantV: Results from the prototype of concurrent vector particle transport simulation in HEP](https://arxiv.org/abs/2005.00949), Amadio et al, 2020 (Fig 25,26)
 - [Search for the standard model Higgs boson decaying to charm quarks](https://cds.cern.ch/record/2682638), CMS Collaboration, 2019 (Fig 1)
 - [Search for long-lived particles decaying to eμν](https://arxiv.org/abs/2012.02696), LHCb Collaboration, 2020


### PR DESCRIPTION
The figure numbering changed in version 2 of my paper. Since arXiv shows the newest version by default, I updated the readme accordingly to avoid future confusion.