### PR TITLE
fix: Remove x-axis margins for ATLAS style

### DIFF
--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -44,6 +44,7 @@ _base = {
     "axes.formatter.use_mathtext": True,
     "axes.autolimit_mode": "round_numbers",
     "axes.unicode_minus": False,
+    "axes.xmargin": 0.0,
     # x/y axis label locations
     "xaxis.labellocation": "right",
     "yaxis.labellocation": "top",


### PR DESCRIPTION
Further resolves #242

By adding

```python
"axes.xmargin": 0.0
```

to ALTAS style it ensures that truncation of the plot along the horizontal axis will occur where the data ends, as is apparently [implemented in ATLAS Style](https://github.com/scikit-hep/mplhep/issues/242#issuecomment-799962065), and avoids creating large horizontal margins around the edges of the plot. Currently it is set to

```
>>> import mplhep
>>> import matplotlib
>>> print(mplhep.__version__)
0.2.17
>>> mplhep.set_style("ATLAS")
>>> print(matplotlib.rcParams["axes.xmargin"])
0.05
```

which if a histogram has a large range of `[0,1000]` (c.f. Issue #242) then 

```
>>> matplotlib.rcParams["axes.xmargin"] * 1000
50.0
```

and

https://github.com/scikit-hep/mplhep/blob/e8d592e2e52a974f0730d2b645cb95b8a86c8398/src/mplhep/styles/atlas.py#L45

will further round up to something like a margin of `200`.