### PR TITLE
feat: Allow customisation of experiment label boldness and LHCb exptext font size

### DIFF
--- a/src/mplhep/label.py
+++ b/src/mplhep/label.py
@@ -31,6 +31,7 @@ def exp_text(
     ax=None,
     fontname=None,
     fontsize=None,
+    bold_exptext=True,
     italic=(False, False),
     pad=0,
 ):
@@ -132,7 +133,7 @@ def exp_text(
         ha="left",
         va=loc1_dict[_exp_loc]["va"],
         fontsize=_font_size * 1.3,
-        fontweight="bold",
+        fontweight="bold" if bold_exptext else "normal",
         fontstyle="italic" if italic[0] else "normal",
         fontname=fontname,
     )

--- a/src/mplhep/lhcb.py
+++ b/src/mplhep/lhcb.py
@@ -61,11 +61,7 @@ def _lhcb_label(**kwargs):
     if "fontsize" not in kwargs:
         kwargs["fontsize"] = 28
     return label_base.exp_label(
-        exp="LHCb",
-        italic=(False, False),
-        fontname="Times New Roman",
-        loc=1,
-        **kwargs
+        exp="LHCb", italic=(False, False), fontname="Times New Roman", loc=1, **kwargs
     )
 
 

--- a/src/mplhep/lhcb.py
+++ b/src/mplhep/lhcb.py
@@ -58,10 +58,11 @@ def _lhcb_label(**kwargs):
             and key in inspect.getfullargspec(label_base.exp_label).kwonlyargs
         ):
             kwargs[key] = value
+    if "fontsize" not in kwargs:
+        kwargs["fontsize"] = 28
     return label_base.exp_label(
         exp="LHCb",
         italic=(False, False),
-        fontsize=28,
         fontname="Times New Roman",
         loc=1,
         **kwargs


### PR DESCRIPTION
I've been using the LHCb style feature of mplhep, which has been really great. 

LHCb plots (most of the time) do not have a bold experiment label (e.g. [lhcb-public](http://lhcb-public.web.cern.ch/)), so I'd like to add a new kwarg allowing the boldness of the experiment text to be customised (boldness is on by default, as before), and made a another small adjustment which makes the LHCb label font size 28 a default, rather than a fixed setting. 

Many thanks in advance!
