### PR TITLE
docs: Fix url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install mplhep
 A tutorial given at PyHEP 2020 is available as a binder [here](https://github.com/andrzejnovak/2020-07-17-pyhep2020-mplhep)
 or you can watch the recording [here](https://www.youtube.com/watch?v=gUziXqCGe0o).
 
-Documentation can be found at [mplhep.readthedocs.io](https://www.youtube.com/watch?v=gUziXqCGe0o).
+Documentation can be found at [mplhep.readthedocs.io](https://mplhep.readthedocs.io).
 
 ### Styling
 


### PR DESCRIPTION
Clicking on mplhep.readthedocs.io in the README.md file leads to a youtube video of PyHEP 2020 instead of the expected webpage https://mplhep.readthedocs.io.

Fix this by changing the hyperlink in the markdown.