### PR TITLE
feat: Allow xlabel/ylabel to be passed through with ax kwarg

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -488,9 +488,6 @@ def hist2dplot(
         if not isinstance(ax, plt.Axes):
             raise ValueError("ax must be a matplotlib Axes object")
 
-    x_axes_label = ""
-    y_axes_label = ""
-
     hist = hist_object_handler(H, xbins, ybins)
 
     # TODO: use Histogram everywhere
@@ -500,8 +497,14 @@ def hist2dplot(
     xbin_centers = xbins[1:] - np.diff(xbins) / float(2)
     ybin_centers = ybins[1:] - np.diff(ybins) / float(2)
 
-    x_axes_label = get_histogram_axes_title(hist.axes[0])
-    y_axes_label = get_histogram_axes_title(hist.axes[1])
+    _x_axes_label = ax.get_xlabel()
+    x_axes_label = (
+        _x_axes_label if _x_axes_label != "" else get_histogram_axes_title(hist.axes[0])
+    )
+    _y_axes_label = ax.get_ylabel()
+    y_axes_label = (
+        _y_axes_label if _y_axes_label != "" else get_histogram_axes_title(hist.axes[1])
+    )
 
     H = H.T
 

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -164,7 +164,12 @@ def histplot(
 
     hists = list(process_histogram_parts(H, bins))
     final_bins, xtick_labels = get_plottable_protocol_bins(hists[0].axes[0])
-    x_axes_label = get_histogram_axes_title(hists[0].axes[0])
+    _x_axes_label = ax.get_xlabel()
+    x_axes_label = (
+        _x_axes_label
+        if _x_axes_label != ""
+        else get_histogram_axes_title(hists[0].axes[0])
+    )
 
     # TODO: use hists everywhere
     h = np.stack([h.values().astype(float) for h in hists])

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -33,7 +33,7 @@ def test_simple(mock_matplotlib):
     bins = [0, 1, 2, 3]
     hep.histplot(h, bins, yerr=True, label="X", ax=ax)
 
-    assert len(ax.mock_calls) == 6
+    assert len(ax.mock_calls) == 8
 
     ax.stairs.assert_called_once_with(
         approx([1.0, 3.0, 2.0]),
@@ -75,7 +75,7 @@ def test_histplot_real(mock_matplotlib):
     hep.histplot([a, b, c], bins=bins, ax=ax, yerr=True, label=["MC1", "MC2", "Data"])
     ax.legend()
     ax.set_title("Raw")
-    assert len(ax.mock_calls) == 18
+    assert len(ax.mock_calls) == 20
 
     ax.reset_mock()
 
@@ -83,7 +83,7 @@ def test_histplot_real(mock_matplotlib):
     hep.histplot([c], bins=bins, ax=ax, yerr=True, histtype="errorbar", label="Data")
     ax.legend()
     ax.set_title("Data/MC")
-    assert len(ax.mock_calls) == 7
+    assert len(ax.mock_calls) == 11
     ax.reset_mock()
 
     hep.histplot(
@@ -100,7 +100,7 @@ def test_histplot_real(mock_matplotlib):
     )
     ax.legend()
     ax.set_title("Data/MC binwnorm")
-    assert len(ax.mock_calls) == 7
+    assert len(ax.mock_calls) == 11
     ax.reset_mock()
 
     hep.histplot(
@@ -117,4 +117,4 @@ def test_histplot_real(mock_matplotlib):
     )
     ax.legend()
     ax.set_title("Data/MC Density")
-    assert len(ax.mock_calls) == 7
+    assert len(ax.mock_calls) == 11


### PR DESCRIPTION
Resolves #327

**Suggested squash and merge message**:
```
* Allow for existing axis xlabel and ylabel to be used to set axis labels if kwarg ax passed.
* Update mock count in tests to account for additional calls
```