### PR TITLE
docs: avoid mention of setup.py <command>

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
 )
 
 # To push on pypi
-# python setup.py sdist
-# twine upload dist/*
+# pipx run build
+# pipx run twine upload dist/*


### PR DESCRIPTION
Even in comments, we should avoid setup.py <command>, see https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html, by a python core developer, and reviewed by members of the packaging authority.