### PR TITLE
Minor doc fix to advertise LHCb2 style

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -15,7 +15,7 @@ primary functionality can be accessed as follows:
    import mplhep as hep
 
    # Load style sheet
-   plt.style.use(hep.style.CMS)  # or ATLAS/LHCb
+   plt.style.use(hep.style.CMS)  # or ATLAS/LHCb2
 
    h, bins = np.histogram(np.random.random(1000))
    fig, ax = plt.subplots()


### PR DESCRIPTION
Simply replace `LHCb` with `LHCb2` in the getting started