### PR TITLE
style: cleanup and additions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         runs-on: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.10"]
         include:
         - runs-on: macOS-latest
-          python-version: 3.7
+          python-version: "3.7"
         - runs-on: macOS-latest
-          python-version: 3.9
+          python-version: "3.9"
 
     steps:
     - uses: actions/checkout@master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,10 @@ repos:
     files: src
     additional_dependencies: [uhi~=0.3.0, numpy~=1.22.0]
     args: [--show-error-codes]
+
+- repo: https://github.com/codespell-project/codespell
+  rev: "v2.1.0"
+  hooks:
+  - id: codespell
+    args: ["-L", "hist,heros"]
+    exclude: "^examples/Examples.ipynb$"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,15 @@ repos:
   - id: codespell
     args: ["-L", "hist,heros"]
     exclude: "^examples/Examples.ipynb$"
+
+- repo: https://github.com/pre-commit/pygrep-hooks
+  rev: "v1.9.0"
+  hooks:
+  - id: python-check-blanket-noqa
+  - id: python-check-blanket-type-ignore
+  - id: python-no-log-warn
+  - id: python-no-eval
+  - id: python-use-type-annotations
+  - id: rst-backticks
+  - id: rst-directive-colons
+  - id: rst-inline-touching-normal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,11 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
+- repo: https://github.com/asottile/setup-cfg-fmt
+  rev: "v1.20.0"
+  hooks:
+  - id: setup-cfg-fmt
+
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
+    args: ["-a", "from __future__ import annotations"]
 
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.31.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,18 +28,16 @@ repos:
     args: ["--py37-plus"]
 
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.2.2
+  rev: 1.2.3
   hooks:
-  - id: nbqa-black
-    additional_dependencies: [black==20.8b1]
   - id: nbqa-pyupgrade
-    additional_dependencies: [pyupgrade==2.7.3]
+    additional_dependencies: [pyupgrade==2.31.0]
     args: ["--py37-plus"]
 
 - repo: https://github.com/psf/black
   rev: 21.12b0
   hooks:
-  - id: black
+  - id: black-jupyter
 
 - repo: https://github.com/PyCQA/flake8
   rev: 4.0.1
@@ -52,4 +50,5 @@ repos:
   hooks:
   - id: mypy
     files: src
-    additional_dependencies: [uhi~=0.2.0, numpy~=1.20.1]
+    additional_dependencies: [uhi~=0.3.0, numpy~=1.22.0]
+    args: [--show-error-codes]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include src/mplhep/.VERSION
+include src/mplhep/version.pyi
 include src/mplhep/stylelib/*.mplstyle
 recursive-include src/mplhep/fonts/ *
 include LICENSE

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ hep.style.use({"font.sans-serif":'Comic Sans MS'})
 # Notes
 
 ## Consistency \& Fonts
-As it is ROOT does not come with any fonts and therefore relies on using system fonts. Therfore the font in a figure can be dependent on whether it was produced on OSX or PC. The default sans-serif font used is Helvetica, but it only comes with OSX, in Windows this will silently fallback to Arial.
+As it is ROOT does not come with any fonts and therefore relies on using system fonts. Therefore the font in a figure can be dependent on whether it was produced on OSX or PC. The default sans-serif font used is Helvetica, but it only comes with OSX, in Windows this will silently fallback to Arial.
 
 ### License
 Both Helvetica and Arial are proprietary, which as far as fonts go means you can use it to create any text/graphics once you have the license, but you cannot redistribute the font files as part of other software. That means we cannot just package Helvetica with this to make sure everyone has the same font in plots.
@@ -146,7 +146,7 @@ You can compare yourself if the differences are meanigful below.
   <img src="img/FontComp.png" width="400" />
 </p>
 
-They are Tex Gyre Heros, Helvetica and Arial respecively.
+They are Tex Gyre Heros, Helvetica and Arial respectively.
 
 ### Math Fonts
 - Math fonts are a separate set from regular fonts due to the amount of special characters

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,7 +11,7 @@ Primary functions.
 
 .. autofunction:: mplhep.hist2dplot
 
-.. # List all modules when apropriately privatized
+.. # List all modules when appropriately privatized
    .. automodule:: mplhep.plot
       :members:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,8 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from __future__ import annotations
+
 # -- Path setup --------------------------------------------------------------
 import importlib
 import inspect

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 .. mplhep documentation master file, created by
    sphinx-quickstart on Sun Apr 12 14:08:38 2020.
    You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+   contain the root ``toctree`` directive.
 
 
 ======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,38 @@
 requires = ["wheel", "setuptools>=42", "setuptools_scm[toml]>=3.4",]
 build-backend = "setuptools.build_meta"
 
+
 [tool.setuptools_scm]
 write_to = "src/mplhep/_version.py"
 
-[tool.nbqa.config]
-black = "pyproject.toml"
 
 [tool.nbqa.mutate]
-black = 1
 pyupgrade = 1
 
 [tool.nbqa.addopts]
-pyupgrade = ["--py36-plus"]
+pyupgrade = ["--py37-plus"]
+
+
+[tools.mypy]
+files = ["src"]
+python_version = 3.7
+warn_unused_configs = true
+
+allow_redefinition = true
+# disallow_any_generics = true
+# disallow_subclassing_any = true
+# disallow_untyped_calls = true
+# disallow_untyped_defs = true
+# disallow_incomplete_defs = true
+check_untyped_defs = true
+# disallow_untyped_decorators = true
+# no_implicit_optional = true
+# warn_redundant_casts = true
+# warn_unused_ignores = true
+# warn_return_any = true
+# no_implicit_reexport = true
+# strict_equality = true
+
+[[tool.mypy.overrides]]
+module = ["matplotlib.*", "cycler", "scipy.*", "mpl_toolkits.*", "mplhep_data"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,14 @@ check_untyped_defs = true
 [[tool.mypy.overrides]]
 module = ["matplotlib.*", "cycler", "scipy.*", "mpl_toolkits.*", "mplhep_data"]
 ignore_missing_imports = true
+
+
+# Additional configuration is in matplotlib/testing/conftest.py.
+[tool.pytest.ini_config]
+minversion = 6.0
+testpaths = ["tests"]
+python_files = "test*.py"
+
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,43 +1,43 @@
 [metadata]
 name = mplhep
-# version = file: src/mplhep/.VERSION
+description = Matplotlib styles for HEP
 long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/scikit-hep/mplhep
 author = andrzejnovak
 author_email = "novak5andrzej@gmail.com"
 maintainer = Scikit-HEP
 maintainer_email = scikit-hep-admins@googlegroups.com
-license = MIT License
-description = Matplotlib styles for HEP
-url = https://github.com/scikit-hep/mplhep
+license = MIT
+license_file = LICENSE
 classifiers =
+    Framework :: Matplotlib
     Intended Audience :: Science/Research
     License :: OSI Approved :: MIT License
-    Framework :: Matplotlib
+    Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Physics
 
-
 [options]
-zip_safe = False
-python_requires = >=3.7
-package_dir =
-    =src
 packages = find:
-include_package_data = True
 install_requires =
-    mplhep_data
     matplotlib>=3.4
+    mplhep-data
     numpy>=1.16.0
     packaging
     uhi>=0.2.0
+python_requires = >=3.7
+include_package_data = True
+package_dir =
+    =src
+zip_safe = False
 
 [options.packages.find]
 where = src
-
 
 [flake8]
 select = B,C,E,F,W,T4,B9

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,34 +38,7 @@ install_requires =
 [options.packages.find]
 where = src
 
-# Additional configuration is in matplotlib/testing/conftest.py.
-[tool:pytest]
-minversion = 3.7
-testpaths = tests
-python_files = test*.py
 
 [flake8]
-# F401: some imports are used by code which is dynamically loaded <- check again later
-max-line-length = 88
 select = B,C,E,F,W,T4,B9
-ignore = E203, E266, E501, W503, B950
-
-# disallow_any_generics = True
-# disallow_subclassing_any = True
-# disallow_untyped_calls = True
-# disallow_untyped_defs = True
-# disallow_incomplete_defs = True
-check_untyped_defs = True
-# disallow_untyped_decorators = True
-# no_implicit_optional = True
-# warn_redundant_casts = True
-# warn_unused_ignores = True
-# warn_return_any = True
-# no_implicit_reexport = True
-# strict_equality = True
-
-=======
->>>>>>> 77dbde5 (chore: update pre-commit hooks and move mypy to toml)
-[tool:isort]
-profile = black
-multi_line_output = 3
+extend-ignore = B950, W503, E501, E203

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,12 +50,6 @@ max-line-length = 88
 select = B,C,E,F,W,T4,B9
 ignore = E203, E266, E501, W503, B950
 
-[mypy]
-files = src
-python_version = 3.7
-warn_unused_configs = True
-
-allow_redefinition = True
 # disallow_any_generics = True
 # disallow_subclassing_any = True
 # disallow_untyped_calls = True
@@ -70,6 +64,8 @@ check_untyped_defs = True
 # no_implicit_reexport = True
 # strict_equality = True
 
+=======
+>>>>>>> 77dbde5 (chore: update pre-commit hooks and move mypy to toml)
 [tool:isort]
 profile = black
 multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 extras_require = {
     "test": [
         "scipy>=1.1.0",
-        "pytest",
+        "pytest>=6.0",
         "pytest-mpl",
         "pytest-mock",
         "papermill~=1.0",

--- a/src/mplhep/__init__.py
+++ b/src/mplhep/__init__.py
@@ -26,7 +26,7 @@ from .plot import (
 )
 from .styles import set_style
 
-## Configs
+# Configs
 rcParams = Config(
     label=Config(
         data=None,

--- a/src/mplhep/_version.pyi
+++ b/src/mplhep/_version.pyi
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 version: str
 version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]

--- a/src/mplhep/label.py
+++ b/src/mplhep/label.py
@@ -44,7 +44,7 @@ def exp_text(
             Secondary experiment label, typically not-bold and smaller
             font-size. For example "Simulation" or "Preliminary"
         loc : int, optional
-            Label positon:
+            Label position:
             - 0 : Above axes, left aligned
             - 1 : Top left corner
             - 2 : Top left corner, multiline
@@ -248,7 +248,7 @@ def exp_label(
     Parameters
     ----------
         loc : int, optional
-            Label positon of ``exp_text`` label:
+            Label position of ``exp_text`` label:
             - 0 : Above axes, left aligned
             - 1 : Top left corner
             - 2 : Top left corner, multiline
@@ -406,7 +406,7 @@ def savelabels(
         ]
         If supplied strings contain suffixes such as ".png" the names will be assumed
         to be absolute and will ignore ``fname``.
-        If current label contains "Simulation" this will be perserved.
+        If current label contains "Simulation" this will be preserved.
     """
     if labels is None:
         labels = [

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -364,10 +364,15 @@ def histplot(
             "markersize": 10.0,
             "elinewidth": 1,
         }
+
+        _xerr: np.ndarray | float | int | None
+
         if xerr is True:
             _xerr = _bin_widths / 2
         elif isinstance(xerr, (int, float)):
             _xerr = xerr
+        else:
+            _xerr = None
 
         for i in range(len(plottables)):
             _plot_info = plottables[i].to_errorbar()

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -438,7 +438,7 @@ def hist2dplot(
         Array of per-bin labels to display. If ``True`` will
         display numerical values
     cbar : bool, optional, default True
-        Draw a colorbar. In contrast to mpl behaviours the cbar axes is
+        Draw a colorbar. In contrast to mpl behaviors the cbar axes is
         appended in such a way that it doesn't modify the original axes
         width:height ratio.
     cbarsize : str or float, optional, default "7%"

--- a/src/mplhep/utils.py
+++ b/src/mplhep/utils.py
@@ -27,7 +27,7 @@ def get_plottable_protocol_bins(
     out = np.arange(len(axis) + 1).astype(float)
     if isinstance(axis[0], tuple):  # Regular axis
         out[0] = axis[0][0]
-        out[1:] = [axis[i][1] for i in range(len(axis))]  # type: ignore
+        out[1:] = [axis[i][1] for i in range(len(axis))]  # type: ignore[index]
         labels = None
     else:  # Categorical axis
         labels = np.array([axis[i] for i in range(len(axis))])
@@ -95,18 +95,20 @@ def process_histogram_parts(
     ):
         return _process_histogram_parts_iter(H, *bins)
     else:
-        return _process_histogram_parts_iter((H,), *bins)  # type: ignore
+        return _process_histogram_parts_iter((H,), *bins)  # type: ignore[arg-type]
 
 
 def _process_histogram_parts_iter(
     hists: Iterable[ArrayLike] | Iterable[PlottableHistogram],
     *bins: Sequence[float | None],
 ) -> Iterable[PlottableHistogram]:
-    original_bins: tuple[Sequence[float], ...] = bins  # type: ignore
+    original_bins: tuple[Sequence[float], ...] = bins  # type: ignore[assignment]
 
     for hist in hists:
         h = hist_object_handler(hist, *bins)
-        current_bins: tuple[Sequence[float], ...] = tuple(get_plottable_protocol_bins(a)[0] for a in h.axes)  # type: ignore
+        current_bins: tuple[Sequence[float], ...] = tuple(
+            get_plottable_protocol_bins(a)[0] for a in h.axes  # type: ignore[misc]
+        )
         if any(b is None for b in original_bins):
             original_bins = current_bins
         if len(current_bins) != len(original_bins):


### PR DESCRIPTION
Formal Python 3.10 support & testing, too.

- chore: update pre-commit hooks and move mypy to toml
- style: move more configuration into toml
- style: from __future__ import annotations enforced
- style: setup.cfg formatting, Python 3.10 testing
- style: add spell checking
- style: add some grep checks
