### PR TITLE
chore: remove "wheel" from build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system (setup.py) to execute.
-requires = ["wheel", "setuptools>=42", "setuptools_scm[toml]>=3.4",]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4",]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
Not needed via PEP 517, provided by `get_requires_for_build_wheel`.