### PR TITLE
feat: add lumi_format option to exp_label

### DIFF
--- a/src/mplhep/label.py
+++ b/src/mplhep/label.py
@@ -236,6 +236,7 @@ def exp_label(
     label="",
     year=None,
     lumi=None,
+    lumi_format="{0}",
     com=None,
     llabel=None,
     rlabel=None,
@@ -268,6 +269,8 @@ def exp_label(
             Year when data was collected
         lumi : float, optional
             Aggregate luminosity shown. Should require ``"data"`` to be ``True``.
+        lumi_format : string, optional, default is `"{0}"`
+            Format string for luminosity number, e.g. `"{0:.1f}"`
         com: float, optional, default is 13, but can be changed to 7/8/13.6/14 to fit different requirements
         llabel : string, optional
             String to manually set left-hand label text. Will overwrite "data" and
@@ -301,7 +304,7 @@ def exp_label(
     else:
         if lumi is not None:
             _lumi = r"{lumi}{year} ({com} TeV)".format(
-                lumi=str(lumi) + r" $\mathrm{fb^{-1}}$",
+                lumi=lumi_format.format(lumi) + r" $\mathrm{fb^{-1}}$",
                 year=", " + str(year) if year is not None else "",
                 com=str(com) if com is not None else "13",
             )


### PR DESCRIPTION
Currently, the integrated luminosity is passed as float and is simply converted to a string for the lumi label, potentially resulting in a lot of decimal places being shown. Usually, one has to reduce the fixed floating point precision to a more reasonable one. 

Instead of letting the user round down the number manually before passing it, this adds a `lumi_format` option to `exp_label` to change how the number is formatted. The current default behaviour is unchanged.

Edit: an alternative would be to simply let the user pass the lumi as an already-formatted string. WDYT?