### PR TITLE
fix: remote `r_align` from `__all__`

### DIFF
--- a/src/mplhep/__init__.py
+++ b/src/mplhep/__init__.py
@@ -63,7 +63,6 @@ __all__ = [
     "histplot",
     "hist2dplot",
     "mpl_magic",
-    "r_align",
     "yscale_legend",
     "ylow",
     "rescale_to_axessize",


### PR DESCRIPTION
This change was originally made in #185