### PR TITLE
feat: Add errorband plotting to histplot

### DIFF
--- a/src/mplhep/__init__.py
+++ b/src/mplhep/__init__.py
@@ -17,6 +17,7 @@ from .plot import (
     box_aspect,
     hist2dplot,
     histplot,
+    errorband,
     make_square_add_cbar,
     mpl_magic,
     rescale_to_axessize,
@@ -61,6 +62,7 @@ __all__ = [
     "savelabels",
     # Log plot functions
     "histplot",
+    "errorband",
     "hist2dplot",
     "mpl_magic",
     "yscale_legend",


### PR DESCRIPTION
Adds a function to plot errorbands as well as integration of errorbands into `histplot` when plotting with `histstyle="fill"` and specifying `yerr`, addressing #26 .