### PR TITLE
fix: flow warning fix

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -509,7 +509,8 @@ def histplot(
 
     if x_axes_label:
         ax.set_xlabel(x_axes_label)
-    if flow == "hint" or flow == "show":
+
+    if flow in {"hint", "show"} and (underflow > 0.0 or overflow > 0.0):
         d = 0.9  # proportion of vertical to horizontal extent of the slanted line
         trans = mpl.transforms.blended_transform_factory(ax.transData, ax.transAxes)
         ax_h = ax.bbox.height

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -72,7 +72,7 @@ def histplot(
     edges=True,
     binticks=False,
     ax=None,
-    flow=None,
+    flow="hint",
     **kwargs,
 ):
     """
@@ -133,7 +133,7 @@ def histplot(
             Attempts to draw x-axis ticks coinciding with bin boundaries if feasible.
         ax : matplotlib.axes.Axes, optional
             Axes object (if None, last one is fetched or one is created)
-        flow :  str, optional { "show", "sum", "hint", None}
+        flow :  str, optional { "show", "sum", "hint", "none"}
             Whether plot the under/overflow bin. If "show", add additional under/overflow bin. If "sum", add the under/overflow bin content to first/last bin.
         **kwargs :
             Keyword arguments passed to underlying matplotlib functions -
@@ -211,16 +211,11 @@ def histplot(
     flow_bins = final_bins
     for i, h in enumerate(hists):
         value, variance = h.values(), h.variances()
-        if (
-            hasattr(h, "values")
-            and "flow" not in inspect.getfullargspec(h.values).args
-            and flow is not None
-        ):
+        if hasattr(h, "values") and "flow" not in inspect.getfullargspec(h.values).args:
             if flow == "sum" or flow == "show":
                 warnings.warn(
                     f"{type(h)} is not allowed to get flow bins", stacklevel=2
                 )
-            flow = None
             plottables.append(Plottable(value, edges=final_bins, variances=variance))
         # check if the original hist has flow bins
         elif (
@@ -229,10 +224,9 @@ def histplot(
             and hasattr(h.axes[0].traits, "underflow")
             and not h.axes[0].traits.underflow
             and not h.axes[0].traits.overflow
-            and flow in {"show", "hint", "sum"}
+            and flow in {"show", "sum"}
         ):
             warnings.warn(f"You don't have flow bins stored in {h!r}", stacklevel=2)
-            flow = None
             plottables.append(Plottable(value, edges=final_bins, variances=variance))
         elif flow == "hint":
             plottables.append(Plottable(value, edges=final_bins, variances=variance))


### PR DESCRIPTION
This is the full suggested fix to the issues introduced in #413:

* Made the output a warning
* Used the repr of the histogram instead of the print (which is a textual plot)
* Avoided printing the warning if "none"/None is set for `flow=`.

Personally, I'd recommend not supporting `None`, and only supporting `"none"`, since it's just a mode like the others and it's not the default if no argument is passed.

I think "hint" should also not print a warning.

