### PR TITLE
ci: Use scientific-python-nightly-wheels for dependency nightlies

### DIFF
--- a/.github/workflows/head-dependencies.yml
+++ b/.github/workflows/head-dependencies.yml
@@ -76,7 +76,12 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pytest-github-actions-annotate-failures
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
-        python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
+        python -m pip install \
+          --upgrade \
+          --pre \
+          --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+          --extra-index-url https://pypi.org/simple/ \
+          matplotlib
 
     - name: List installed Python packages
       run: python -m pip list


### PR DESCRIPTION
Copy of https://github.com/scikit-hep/pyhf/pull/2225

* Nightly wheels for the Scientific Python community have migrated from the Anaconda Cloud https://anaconda.org/scipy-wheels-nightly/ package index to https://anaconda.org/scientific-python-nightly-wheels.
   - c.f. https://scientific-python.org/specs/spec-0004/
   - c.f. https://github.com/scientific-python/specs/pull/182
   - c.f. https://github.com/matplotlib/matplotlib/pull/25950
* For matplotlib use `--index-url` of `scientific-python-nightly-wheels` and use `--extra-index-url` of public PyPI (https://pypi.org/) as some of matplotlib's dependencies aren't on scientific-python-nightly-wheels.