### PR TITLE
Restrict mpl st 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    matplotlib>=3.4
+    matplotlib>=3.4, <3.8
     mplhep-data
     numpy>=1.16.0
     packaging


### PR DESCRIPTION
Fixes #441 to make sure projects with mplhep don't fail now. We can fix the actualy issue, i.e. replace the [removed module docstring](https://matplotlib.org/3.8.0/api/prev_api_changes/api_changes_3.8.0.html#deprecated-modules-removed), maybe @andrzejnovak has some ideas already?