### PR TITLE
fix: _chunked_kwargs not expanding kwargs if they're tuples even if t…

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -306,7 +306,9 @@ def histplot(
         # Check if iterable
         if iterable_not_string(kwargs[kwarg]):
             # Check if tuple of floats or ints (can be used for colors)
-            all_entries_numerical = all(isinstance(x, int) or isinstance(x, float) for x in kwargs[kwarg])
+            all_entries_numerical = all(
+                isinstance(x, int) or isinstance(x, float) for x in kwargs[kwarg]
+            )
             if isinstance(kwargs[kwarg], tuple) and all_entries_numerical:
                 for i in range(len(_chunked_kwargs)):
                     _chunked_kwargs[i][kwarg] = kwargs[kwarg]

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -305,8 +305,9 @@ def histplot(
     for kwarg in kwargs:
         # Check if iterable
         if iterable_not_string(kwargs[kwarg]):
-            # Check if tuple (can be used for colors)
-            if isinstance(kwargs[kwarg], tuple):
+            # Check if tuple of floats or ints (can be used for colors)
+            all_entries_numerical = all(isinstance(x, int) or isinstance(x, float) for x in kwargs[kwarg])
+            if isinstance(kwargs[kwarg], tuple) and all_entries_numerical:
                 for i in range(len(_chunked_kwargs)):
                     _chunked_kwargs[i][kwarg] = kwargs[kwarg]
             else:


### PR DESCRIPTION
fix: _chunked_kwargs not expanding kwargs if they're tuples even if the tuple isn't a valid mpl color.

This issue confused me for a long time and is likely to come up if one uses the 'zip' builtin to zip up colours and histograms. Although this could be fixed by simply converting the tuple of colors returned by zip into a list, this is a better solution as it does not require users to read the source code to figure this out.