### PR TITLE
fix: make passing colors as tuple safe

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -306,10 +306,9 @@ def histplot(
         # Check if iterable
         if iterable_not_string(kwargs[kwarg]):
             # Check if tuple of floats or ints (can be used for colors)
-            all_entries_numerical = all(
+            if isinstance(kwargs[kwarg], tuple) and all(
                 isinstance(x, int) or isinstance(x, float) for x in kwargs[kwarg]
-            )
-            if isinstance(kwargs[kwarg], tuple) and all_entries_numerical:
+            ):
                 for i in range(len(_chunked_kwargs)):
                     _chunked_kwargs[i][kwarg] = kwargs[kwarg]
             else:


### PR DESCRIPTION
Hi, sorry to raise this again, but it occurred to me that the previous solution would have nasty effects if you passed a generator in as an argument as it would loop through all the items in the generator. This is a safer implementation thanks to short-circuit evaluation.