### PR TITLE
fix: support older matplotlib

### DIFF
--- a/src/mplhep/_compat.py
+++ b/src/mplhep/_compat.py
@@ -2,9 +2,9 @@ import matplotlib
 from packaging.version import parse as parse_version
 
 if parse_version(matplotlib.__version__) < parse_version("3.8.0"):
-    from matplotlib import docstring
+    from matplotlib import docstring  # type: ignore[attr-defined]
 else:
-    from matplotlib import _docstring as docstring
+    from matplotlib import _docstring as docstring  # type: ignore[attr-defined]
 
 
 __all__ = ("docstring",)

--- a/src/mplhep/_compat.py
+++ b/src/mplhep/_compat.py
@@ -1,0 +1,10 @@
+import matplotlib
+from packaging.version import parse as parse_version
+
+if parse_version(matplotlib.__version__) < parse_version("3.8.0"):
+    from matplotlib import docstring
+else:
+    from matplotlib import _docstring as docstring
+
+
+__all__ = ("docstring",)

--- a/src/mplhep/alice.py
+++ b/src/mplhep/alice.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import inspect
 
-from matplotlib import _docstring as docstring
+import matplotlib
+from packaging.version import parse as parse_version
+
+if parse_version(matplotlib.__version__) < parse_version("3.8.0"):
+    from matplotlib import docstring
+else:
+    from matplotlib import _docstring as docstring
 
 import mplhep
 

--- a/src/mplhep/alice.py
+++ b/src/mplhep/alice.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 import inspect
 
-import matplotlib
-from packaging.version import parse as parse_version
-
-if parse_version(matplotlib.__version__) < parse_version("3.8.0"):
-    from matplotlib import docstring
-else:
-    from matplotlib import _docstring as docstring
+from ._compat import docstring
 
 import mplhep
 

--- a/src/mplhep/atlas.py
+++ b/src/mplhep/atlas.py
@@ -6,6 +6,8 @@ import matplotlib as mpl
 
 import mplhep
 
+from ._compat import docstring
+
 from . import label as label_base
 from .label import lumitext
 
@@ -15,7 +17,7 @@ from .styles import atlas as style
 __all__ = ("style", "lumitext")
 
 
-@mpl._docstring.copy(label_base.exp_text)
+@docstring.copy(label_base.exp_text)
 def text(text="", **kwargs):
     for key, value in dict(mplhep.rcParams.text._get_kwargs()).items():
         if (
@@ -29,7 +31,7 @@ def text(text="", **kwargs):
     return label_base.exp_text("ATLAS", text=text, **kwargs)
 
 
-@mpl._docstring.copy(label_base.exp_label)
+@docstring.copy(label_base.exp_label)
 def label(label=None, **kwargs):
     for key, value in dict(mplhep.rcParams.label._get_kwargs()).items():
         if (

--- a/src/mplhep/cms.py
+++ b/src/mplhep/cms.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 
-from matplotlib import _docstring as docstring
+from ._compat import docstring
 
 import mplhep
 

--- a/src/mplhep/lhcb.py
+++ b/src/mplhep/lhcb.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import inspect
 
-from matplotlib import _docstring as docstring
+from ._compat import docstring
 
 import mplhep
 from mplhep import label as label_base


### PR DESCRIPTION
#443 broke support for older matplotlib (within our version bounds). This PR adds a version check.