### PR TITLE
feat: new "band" histtype

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -152,7 +152,7 @@ def histplot(
             raise ValueError("ax must be a matplotlib Axes object")
 
     # arg check
-    _allowed_histtype = ["fill", "step", "errorbar"]
+    _allowed_histtype = ["fill", "step", "errorbar", "band"]
     _err_message = f"Select 'histtype' from: {_allowed_histtype}"
     assert histtype in _allowed_histtype, _err_message
     assert flow is None or flow in {
@@ -462,6 +462,23 @@ def histplot(
             return_artists.append(StairsArtists(_f, None, None))
         _artist = _f
 
+    elif histtype == "band":
+        band_defaults = {
+            "alpha": 0.5,
+            "edgecolor": "lightgray",
+            "hatch": "///",
+        }
+        for i in range(len(plottables)):
+            _kwargs = _chunked_kwargs[i]
+            _f = ax.stairs(
+                **plottables[i].to_stairband(),
+                label=_labels[i],
+                fill=True,
+                **soft_update_kwargs(_kwargs, band_defaults),
+            )
+            return_artists.append(StairsArtists(_f, None, None))
+        _artist = _f
+
     elif histtype == "errorbar":
         err_defaults = {
             "linestyle": "none",
@@ -480,6 +497,7 @@ def histplot(
             _xerr = None
 
         for i in range(len(plottables)):
+            _kwargs = _chunked_kwargs[i]
             _plot_info = plottables[i].to_errorbar()
             if yerr is False:
                 _plot_info["yerr"] = None
@@ -487,7 +505,7 @@ def histplot(
             _e = ax.errorbar(
                 **_plot_info,
                 label=_labels[i],
-                **soft_update_kwargs(_chunked_kwargs[i], err_defaults),
+                **soft_update_kwargs(_kwargs, err_defaults),
             )
             return_artists.append(ErrorBarArtists(_e))
 

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -90,7 +90,7 @@ def histplot(
 
             Or list thereof.
         bins : iterable, optional
-            Histogram bins, if not part of ``h``.
+            Histogram bins, if not part of ``H``.
         yerr : iterable or bool, optional
             Histogram uncertainties. Following modes are supported:
             - True, sqrt(N) errors or poissonian interval when ``w2`` is specified
@@ -115,12 +115,13 @@ def histplot(
         binwnorm : float, optional
             If true, convert sum weights to bin-width-normalized, with unit equal to
                 supplied value (usually you want to specify 1.)
-        histtype: {'step', 'fill', 'errorbar'}, optional, default: "step"
+        histtype: {'step', 'fill', 'band', 'errorbar'}, optional, default: "step"
             Type of histogram to plot:
 
-            - "step": skyline/step/outline of a histogram using `plt.step <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.step.html#matplotlib.axes.Axes.step>`_
-            - "fill": filled histogram using `plt.fill_between <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.step.html#matplotlib.axes.Axes.step>`_
-            - "errorbar": single marker histogram using `plt.errorbar <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.step.html#matplotlib.axes.Axes.step>`_
+            - "step": skyline/step/outline of a histogram using `plt.stairs <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.stairs.html#matplotlib-axes-axes-stairs>`_
+            - "fill": filled histogram using `plt.stairs <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.stairs.html#matplotlib-axes-axes-stairs>`_
+            - "step": filled band spanning the yerr range of the histogram using `plt.stairs <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.stairs.html#matplotlib-axes-axes-stairs>`_
+            - "errorbar": single marker histogram using `plt.errorbar <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.errorbar.html#matplotlib-axes-axes-errorbar>`_
         xerr:  bool or float, optional
             Size of xerr if ``histtype == 'errorbar'``. If ``True``, bin-width will be used.
         label : str or list, optional
@@ -134,10 +135,11 @@ def histplot(
         ax : matplotlib.axes.Axes, optional
             Axes object (if None, last one is fetched or one is created)
         flow :  str, optional { "show", "sum", "hint", "none"}
-            Whether plot the under/overflow bin. If "show", add additional under/overflow bin. If "sum", add the under/overflow bin content to first/last bin.
+            Whether plot the under/overflow bin. If "show", add additional under/overflow bin.
+            If "sum", add the under/overflow bin content to first/last bin.
         **kwargs :
             Keyword arguments passed to underlying matplotlib functions -
-            {'step', 'fill_between', 'errorbar'}.
+            {'stairs', 'errorbar'}.
     Returns
     -------
         List[Hist1DArtists]
@@ -465,8 +467,9 @@ def histplot(
     elif histtype == "band":
         band_defaults = {
             "alpha": 0.5,
-            "edgecolor": "lightgray",
-            "hatch": "///",
+            "edgecolor": "darkgray",
+            "facecolor": "whitesmoke",
+            "hatch": "////  /",
         }
         for i in range(len(plottables)):
             _kwargs = _chunked_kwargs[i]

--- a/src/mplhep/utils.py
+++ b/src/mplhep/utils.py
@@ -265,6 +265,14 @@ class Plottable:
     def to_stairs(self):
         return {"values": self.values, "edges": self.edges, "baseline": self.baseline}
 
+    def to_stairband(self):
+        self.errors()
+        return {
+            "values": self.values + self.yerr_hi,
+            "edges": self.edges,
+            "baseline": self.values - self.yerr_lo,
+        }
+
     def to_errorbar(self):
         self.errors()
         return {


### PR DESCRIPTION
Adding an error "band" plot style. I am envisioning usage like this 
```
h = hist.new.Reg(10, 0, 1, flow=False).Weight().fill(np.random.normal(0.5, 0.3, 1000))
hep.histplot(h)
hep.histplot(h, histtype='band')
```
![image](https://github.com/scikit-hep/mplhep/assets/13226500/97fb8a8a-e10a-480f-bbf0-b22c60f84447)

What do you think of the defaults @alexander-held @matthewfeickert @iasonkrom ?