### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/head-dependencies.yml
+++ b/.github/workflows/head-dependencies.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         python-version: ['3.11']
 
     steps:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos