### PR TITLE
fix: legend linestyle for step histogram

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -416,6 +416,7 @@ def histplot(
 
             if do_errors:
                 _kwargs = soft_update_kwargs(_kwargs, {"color": _s.get_edgecolor()})
+                _ls = _kwargs["linestyle"]
                 _kwargs["linestyle"] = "none"
                 _plot_info = plottables[i].to_errorbar()
                 _e = ax.errorbar(
@@ -423,7 +424,7 @@ def histplot(
                     **_kwargs,
                 )
                 _e_leg = ax.errorbar(
-                    [], [], yerr=1, xerr=1, color=_s.get_edgecolor(), label=_label
+                    [], [], yerr=1, xerr=None, color=_s.get_edgecolor(), label=_label, linestyle=_ls
                 )
             return_artists.append(
                 StairsArtists(

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -416,7 +416,7 @@ def histplot(
 
             if do_errors:
                 _kwargs = soft_update_kwargs(_kwargs, {"color": _s.get_edgecolor()})
-                _ls = _kwargs["linestyle"]
+                _ls = _kwargs.pop("linestyle", "-")
                 _kwargs["linestyle"] = "none"
                 _plot_info = plottables[i].to_errorbar()
                 _e = ax.errorbar(

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -56,7 +56,8 @@ def test_simple(mock_matplotlib):
         approx([]),
         approx([]),
         yerr=1,
-        xerr=1,
+        xerr=None,
+        linestyle='-',
         color=ax.stairs().get_edgecolor(),
         label="X",
     )


### PR DESCRIPTION
The legend entries for `mplhep.histplot` for `histtype='step'` shows always continuous entires no matter what `linestyle` arg is defined. In order to fix that the linestyle is forwarded to `_e_leg` and `xerr` is set to `None` as it is not used in the step mode. 