### PR TITLE
fix: remove precision specifier for flow bin labels

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -551,8 +551,8 @@ def histplot(
             )
 
     elif flow == "show":
-        underflow_xticklabel = f"<{flow_bins[1]:.2g}"
-        overflow_xticklabel = f">{flow_bins[-2]:.2g}"
+        underflow_xticklabel = f"<{flow_bins[1]:g}"
+        overflow_xticklabel = f">{flow_bins[-2]:g}"
 
         # Loop over shared x axes to get xticks and xticklabels
         xticks, xticklabels = np.array([]), []


### PR DESCRIPTION
I modified the flow bin labels to use the exponential formatter because I wanted to remove trailing zeros, however, it will use the specified precision to set the point at which it switches from float to exponential notation.

The code as is produces plots like this:
![8e1c6589-6967-45b9-a49c-88d359f0daf4](https://github.com/scikit-hep/mplhep/assets/47793576/ee03d6ac-5993-47ff-8fb7-46c290845f4d)

My suggestion is to remove the precision specifier which will by default use exponential notation after e-4 or e+5. This switch over is shown here:
![cd103d1f-0a72-4fda-9105-d96a1ead5c54](https://github.com/scikit-hep/mplhep/assets/47793576/6199a4c3-f6b8-4602-b4a1-fb1a867048e1)
![aa1cd4f7-aca1-4292-9ca6-1500fce3d624](https://github.com/scikit-hep/mplhep/assets/47793576/718d08c8-80d8-49ad-80c9-a1048aa93fc6)

It looks like the default is equivalent to setting the precision to 6, that is `.6g` = `g` as far as I can tell. This formatter doesn't seem to differentiate between the number of significant digits it keeps and the point at which it switches over from the float to exponential representation.

The original formatting that `mplhep` used was whatever the python f strings use by default. This shows all the decimals and truncates all trailing zeros except one. It will switch to exponential notation after e-4 but I'm not sure it ever switches over on the high side. For example:
![a09e1d2c-ebbb-450c-ab4b-59a33d8eab8d](https://github.com/scikit-hep/mplhep/assets/47793576/7b6505c6-d626-4d3e-a5d3-3399839120df)

