### PR TITLE
Adding ATLAS recommended color wheel

### DIFF
--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -4,6 +4,10 @@ from typing import Any
 
 import matplotlib as mpl
 
+# Color wheel from https://arxiv.org/pdf/2107.02270 Table 1, 10 color palette
+color_sequence = ['#3f90da','#ffa90e','#bd1f01','#94a4a2','#832db6'
+                  '#a96b59','#e76300','#b9ac70','#717581','#92dadd']
+
 _base = {
     # fonts and text
     # initially from https://github.com/kratsg/ATLASstylempl
@@ -34,6 +38,7 @@ _base = {
     "figure.subplot.left": 0.16,
     "figure.subplot.right": 0.95,
     # axes
+    "axes.prop_cycle": cycler("color", color_sequence),
     "axes.titlesize": "xx-large",
     "axes.labelsize": "x-large",
     "axes.linewidth": 1,


### PR DESCRIPTION
Adding a recommended 10-color palette for ATLAS style. After discussion within the D&I group in ATLAS, we decided to adopt conceptually the same offering as CMS recently did, with a 10-color accessible color palette as a default offering based on https://arxiv.org/abs/2107.02270 . As mentioned, credit to CMS (https://cms.cern/news/cms-collaboration-sets-standard-inclusivity-colour-vision-deficiency-friendly-palettes) for doing this first!