### PR TITLE
fix: make left label read COM energy

### DIFF
--- a/src/mplhep/label.py
+++ b/src/mplhep/label.py
@@ -414,12 +414,18 @@ def exp_label(
             units="inches",
             fig=ax.figure,
         )
+
+        if com is not None:
+            _com_label = r"\mathrm{" + str(com) + r"\ TeV}"
+        else:
+            _com_label = r"\mathrm{13\ TeV}"
+
         if lumi is not None:
             _lumi = (
-                r"$\sqrt{s} = \mathrm{13\ TeV}, " + str(lumi) + r"\ \mathrm{fb}^{-1}$"
+                r"$\sqrt{s} = " + _com_label + ", " + str(lumi) + r"\ \mathrm{fb}^{-1}$"
             )
         else:
-            _lumi = r"$\sqrt{s} = \mathrm{13\ TeV}$"
+            _lumi = r"$\sqrt{s} = " + _com_label + "$"
         explumi = ExpSuffix(
             *exptext.get_position(),
             text=rlabel if rlabel is not None else _lumi,


### PR DESCRIPTION
Previously, only right-side experimental labels actually read the COM energy. This commit makes the left-side labels do the same. The default remains at 13 TeV if no COM energy is supplied.

This was a problem with ATLAS labels for LHC Run 3, since the COM energy is now 13.6. We probably want the flexibility to use this package at various COM energies, so I did not just update the text from 13 to 13.6.