### PR TITLE
chore: add _version.py to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project specific
+src/mplhep/_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
When installing mplhep from a local copy of the git repo, the file `src/mplhep/_version.py` is created (or when building the package in a local repo.).

I think this should be added it to .gitignore.