### PR TITLE
build: Remove 'toml' extra from setuptools_scm build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system (setup.py) to execute.
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4",]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
* The toml extra from setuptools-scm is now empty and exists only for legacy purposes and so can be removed.
* The modern setuptools-scm docs recommend a lower bound of setuptools v64 and setuptools-scm v8.
   - c.f. https://setuptools-scm.readthedocs.io/en/v8.1.0/