### PR TITLE
ci: add 3.13 tests and classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.10", "3.11", "3.12" "3.13"]
+        python-version: [ "3.8", "3.10", "3.11", "3.12", "3.13"]
         include:  # testing the last "reasonable supported" version
           - runs-on: macOS-13
             python-version: "3.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         runs-on: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.10", "3.11", "3.12" "3.13"]
         include:  # testing the last "reasonable supported" version
           - runs-on: macOS-13
             python-version: "3.9"
           - runs-on: macOS-14
-            python-version: "3.10"  # min version available for Apple silicon
+            python-version: "3.8"  # min version available for Apple silicon
           - runs-on: windows-latest
             python-version: "3.9"
 
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install core fonts
         if: runner.os == 'Linux'
@@ -42,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel pytest-github-actions-annotate-failures
+          python -m pip install --upgrade pip pytest-github-actions-annotate-failures
           python -m pip install -q --no-cache-dir -e .[all]
           python -m pip list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,6 @@ dev = [
 test = [
     "boost_histogram",
     "hist",
-    "nteract-scrapbook~=0.3",
-    "papermill~=1.0",
     "pytest-mock",
     "pytest-mpl",
     "pytest>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [


### PR DESCRIPTION
Can we change the default branch to `main`? It's currently some old back port branch.