### PR TITLE
Correct ax.legend() order for stack hists

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections.abc
 import inspect
+import itertools
 import logging
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, NamedTuple, Union
@@ -377,6 +378,20 @@ def histplot(
         plottables = [plottables[ix] for ix in order]
         _chunked_kwargs = [_chunked_kwargs[ix] for ix in order]
         _labels = [_labels[ix] for ix in order]
+
+    elif stack:
+        # Sort from top to bottom so ax.legend() works as expected
+        order = np.argsort(label)[::-1]
+        plottables = [plottables[ix] for ix in order]
+        _chunked_kwargs = [_chunked_kwargs[ix] for ix in order]
+        _labels = [_labels[ix] for ix in order]
+        if "color" not in kwargs:
+            # Inverse default color cycle
+            _colors = itertools.cycle(
+                plt.rcParams["axes.prop_cycle"][len(plottables) - 1 :: -1]
+            )
+            for i in range(len(plottables)):
+                _chunked_kwargs[i].update(next(_colors))
 
     # ############################
     # # Stacking, norming, density

--- a/src/mplhep/utils.py
+++ b/src/mplhep/utils.py
@@ -294,6 +294,8 @@ class Plottable:
 
 
 def stack(*plottables):
+    # Sort from top to bottom so ax.legend() works as expected
+    plottables = plottables[::-1]
     baseline = np.nan_to_num(copy.deepcopy(plottables[0].values), 0)
     for i in range(1, len(plottables)):
         _mask = np.isnan(plottables[i].values)
@@ -303,7 +305,7 @@ def stack(*plottables):
         baseline += np.nan_to_num(plottables[i].values, 0)
         plottables[i].values = np.nansum([plottables[i].values, _baseline], axis=0)
         plottables[i].values[_mask] = np.nan
-    return plottables
+    return plottables[::-1]
 
 
 def align_marker(


### PR DESCRIPTION
Part of the [merging project](https://github.com/orgs/scikit-hep/projects/21).