### PR TITLE
refactor: factor get_plottables logic out of histplot

### DIFF
--- a/src/mplhep/__init__.py
+++ b/src/mplhep/__init__.py
@@ -27,6 +27,7 @@ from .plot import (
     yscale_legend,
 )
 from .styles import set_style
+from .utils import get_plottables
 
 # Configs
 rcParams = Config(
@@ -76,4 +77,5 @@ __all__ = [
     "sort_legend",
     "save_variations",
     "set_style",
+    "get_plottables",
 ]

--- a/src/mplhep/utils.py
+++ b/src/mplhep/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 import warnings
 from numbers import Real
 from typing import TYPE_CHECKING, Any, Iterable, Sequence
@@ -52,8 +53,7 @@ def hist_object_handler(
             hist = (hist, None)
         hist_obj = ensure_plottable_histogram(hist)
     elif isinstance(hist, PlottableHistogram):
-        msg = "Cannot give bins with existing histogram"
-        raise TypeError(msg)
+        hist_obj = hist
     else:
         hist_obj = ensure_plottable_histogram((hist, *bins))
 
@@ -135,14 +135,297 @@ def get_histogram_axes_title(axis: Any) -> str:
     return ""
 
 
+def get_plottables(
+    H,
+    bins=None,
+    yerr: ArrayLike | bool | None = None,
+    w2=None,
+    w2method=None,
+    flow="hint",
+    stack=False,
+    density=False,
+    binwnorm=None,
+):
+    """
+    Generate plottable histograms from various histogram data sources.
+
+    Parameters
+    ----------
+    H : object
+        Histogram object with containing values and optionally bins. Can be:
+
+        - `np.histogram` tuple
+        - PlottableProtocol histogram object
+        - `boost_histogram` classic (<0.13) histogram object
+        - raw histogram values, provided `bins` is specified.
+
+        Or list thereof.
+    bins : iterable, optional
+        Histogram bins, if not part of ``H``.
+    yerr : iterable or bool, optional
+        Histogram uncertainties. Following modes are supported:
+        - True, sqrt(N) errors or poissonian interval when ``w2`` is specified
+        - shape(N) array of for one sided errors or list thereof
+        - shape(Nx2) array of for two sided errors or list thereof
+    w2 : iterable, optional
+        Sum of the histogram weights squared for poissonian interval error
+        calculation
+    w2method: callable, optional
+        Function calculating CLs with signature ``low, high = fcn(w, w2)``. Here
+        ``low`` and ``high`` are given in absolute terms, not relative to w.
+        Default is ``None``. If w2 has integer values (likely to be data) poisson
+        interval is calculated, otherwise the resulting error is symmetric
+        ``sqrt(w2)``. Specifying ``poisson`` or ``sqrt`` will force that behaviours.
+    flow :  str, optional { "show", "sum", "hint", "none"}
+        Whether plot the under/overflow bin. If "show", add additional under/overflow bin.
+        If "sum", add the under/overflow bin content to first/last bin.
+    stack : bool, optional
+        Whether to stack or overlay non-axis dimension (if it exists). N.B. in
+        contrast to ROOT, stacking is performed in a single call aka
+        ``histplot([h1, h2, ...], stack=True)`` as opposed to multiple calls.
+    density : bool, optional
+        If true, convert sum weights to probability density (i.e. integrates to 1
+        over domain of axis) (Note: this option conflicts with ``binwnorm``)
+    binwnorm : float, optional
+        If true, convert sum weights to bin-width-normalized, with unit equal to
+            supplied value (usually you want to specify 1.)
+
+    Returns
+    -------
+    plottables : list of Plottable
+        Processed histogram objects ready for plotting.
+    (flow_bins, underflow, overflow) : tuple
+        Flow bin information for handling underflow and overflow values.
+    """
+    plottables = []
+    flow_bins = np.copy(bins)
+
+    hists = list(process_histogram_parts(H, bins))
+    final_bins, _ = get_plottable_protocol_bins(hists[0].axes[0])
+
+    for h in hists:
+        value, variance = np.copy(h.values()), h.variances()
+        if has_variances := variance is not None:
+            variance = np.copy(variance)
+        underflow, overflow = 0.0, 0.0
+        underflowv, overflowv = 0.0, 0.0
+        # One sided flow bins - hist (uproot hist does not have the over- or underflow traits)
+        if (
+            hasattr(h, "axes")
+            and (traits := getattr(h.axes[0], "traits", None)) is not None
+            and hasattr(traits, "underflow")
+            and hasattr(traits, "overflow")
+        ):
+            if traits.overflow:
+                overflow = np.copy(h.values(flow=True))[-1]
+                if has_variances:
+                    overflowv = np.copy(h.variances(flow=True))[-1]
+            if traits.underflow:
+                underflow = np.copy(h.values(flow=True))[0]
+                if has_variances:
+                    underflowv = np.copy(h.variances(flow=True))[0]
+        # Both flow bins exist - uproot
+        elif hasattr(h, "values") and "flow" in inspect.getfullargspec(h.values).args:
+            if len(h.values()) + 2 == len(
+                h.values(flow=True)
+            ):  # easy case, both over/under
+                underflow, overflow = (
+                    np.copy(h.values(flow=True))[0],
+                    np.copy(h.values(flow=True))[-1],
+                )
+                if has_variances:
+                    underflowv, overflowv = (
+                        np.copy(h.variances(flow=True))[0],
+                        np.copy(h.variances(flow=True))[-1],
+                    )
+
+        # Set plottables
+        if flow in ("none", "hint"):
+            plottables.append(Plottable(value, edges=final_bins, variances=variance))
+        elif flow == "show":
+            _flow_bin_size: float = np.max(
+                [0.05 * (final_bins[-1] - final_bins[0]), np.mean(np.diff(final_bins))]
+            )
+            flow_bins = np.copy(final_bins)
+            if underflow > 0:
+                flow_bins = np.r_[flow_bins[0] - _flow_bin_size, flow_bins]
+                value = np.r_[underflow, value]
+                if has_variances:
+                    variance = np.r_[underflowv, variance]
+            if overflow > 0:
+                flow_bins = np.r_[flow_bins, flow_bins[-1] + _flow_bin_size]
+                value = np.r_[value, overflow]
+                if has_variances:
+                    variance = np.r_[variance, overflowv]
+            plottables.append(Plottable(value, edges=flow_bins, variances=variance))
+        elif flow == "sum":
+            if underflow > 0:
+                value[0] += underflow
+                if has_variances:
+                    variance[0] += underflowv
+            if overflow > 0:
+                value[-1] += overflow
+                if has_variances:
+                    variance[-1] += overflowv
+            plottables.append(Plottable(value, edges=final_bins, variances=variance))
+        else:
+            plottables.append(Plottable(value, edges=final_bins, variances=variance))
+
+    if w2 is not None:
+        for _w2, _plottable in zip(
+            w2.reshape(len(plottables), len(final_bins) - 1), plottables
+        ):
+            _plottable.variances = _w2
+            _plottable.method = w2method
+
+    if w2 is not None and yerr is not None:
+        msg = "Can only supply errors or w2"
+        raise ValueError(msg)
+
+    yerr_plottables(plottables, final_bins, yerr)
+    norm_stack_plottables(plottables, final_bins, stack, density, binwnorm)
+
+    return plottables, (flow_bins, underflow, overflow)
+
+
+def yerr_plottables(plottables, bins, yerr=None):
+    """
+    Calculate and format y-axis errors for Plottables.
+
+    Parameters
+    ----------
+    plottables : list of Plottable
+        List of Plottable objects.
+    bins : iterable
+        Plottable bins.
+    yerr : iterable or bool, optional
+        Histogram uncertainties. Following modes are supported:
+        - True, sqrt(N) errors or poissonian interval when ``w2`` is specified
+        - shape(N) array of for one sided errors or list thereof
+        - shape(Nx2) array of for two sided errors or list thereof
+
+    Raises
+    ------
+    ValueError
+        If `yerr` has an unrecognized format.
+    """
+
+    _yerr: np.ndarray | None
+    if yerr is not None:
+        # yerr is array
+        if hasattr(yerr, "__len__"):
+            _yerr = np.asarray(yerr)
+        # yerr is a number
+        elif isinstance(yerr, (int, float)) and not isinstance(yerr, bool):
+            _yerr = np.ones((len(plottables), len(bins) - 1)) * yerr
+        # yerr is automatic
+        else:
+            _yerr = None
+            for _plottable in plottables:
+                _plottable.errors()
+    else:
+        _yerr = None
+    if _yerr is not None:
+        assert isinstance(_yerr, np.ndarray)
+        if _yerr.ndim == 3:
+            # Already correct format
+            pass
+        elif _yerr.ndim == 2 and len(plottables) == 1:
+            # Broadcast ndim 2 to ndim 3
+            if _yerr.shape[-2] == 2:  # [[1,1], [1,1]]
+                _yerr = _yerr.reshape(len(plottables), 2, _yerr.shape[-1])
+            elif _yerr.shape[-2] == 1:  # [[1,1]]
+                _yerr = np.tile(_yerr, 2).reshape(len(plottables), 2, _yerr.shape[-1])
+            else:
+                msg = "yerr format is not understood"
+                raise ValueError(msg)
+        elif _yerr.ndim == 2:
+            # Broadcast yerr (nh, N) to (nh, 2, N)
+            _yerr = np.tile(_yerr, 2).reshape(len(plottables), 2, _yerr.shape[-1])
+        elif _yerr.ndim == 1:
+            # Broadcast yerr (1, N) to (nh, 2, N)
+            _yerr = np.tile(_yerr, 2 * len(plottables)).reshape(
+                len(plottables), 2, _yerr.shape[-1]
+            )
+        else:
+            msg = "yerr format is not understood"
+            raise ValueError(msg)
+
+        assert _yerr is not None
+        for yrs, _plottable in zip(_yerr, plottables):
+            _plottable.fixed_errors(*yrs)
+
+
+def norm_stack_plottables(plottables, bins, stack=False, density=False, binwnorm=None):
+    """
+    Normalize and stack histogram data with optional density or bin-width normalization.
+
+    Parameters
+    ----------
+    plottables : list of Plottable
+        List of Plottable objects.
+    bins : iterable
+        Plottable bins.
+    stack : bool, optional
+        Whether to stack or overlay non-axis dimension (if it exists). N.B. in
+        contrast to ROOT, stacking is performed in a single call aka
+        ``histplot([h1, h2, ...], stack=True)`` as opposed to multiple calls.
+    density : bool, optional
+        If true, convert sum weights to probability density (i.e. integrates to 1
+        over domain of axis) (Note: this option conflicts with ``binwnorm``)
+    binwnorm : float, optional
+        If true, convert sum weights to bin-width-normalized, with unit equal to
+            supplied value (usually you want to specify 1.)
+
+    Raises
+    ------
+    ValueError
+        If both `density` and `binwnorm` are set, as they are mutually exclusive.
+
+    Notes
+    -----
+    Density and bin-width normalization cannot both be applied simultaneously.
+    For stacked histograms, this function uses an external utility to compute
+    the cumulative stacked values.
+    """
+
+    if density is True and binwnorm is not None:
+        msg = "Can only set density or binwnorm."
+        raise ValueError(msg)
+    if density is True:
+        if stack:
+            _total = np.sum(
+                np.array([plottable.values for plottable in plottables]), axis=0
+            )
+            for plottable in plottables:
+                plottable.flat_scale(1.0 / np.sum(np.diff(bins) * _total))
+        else:
+            for plottable in plottables:
+                plottable.density = True
+    elif binwnorm is not None:
+        for plottable, norm in zip(
+            plottables, np.broadcast_to(binwnorm, (len(plottables),))
+        ):
+            plottable.flat_scale(norm)
+            plottable.binwnorm()
+
+    # Stack
+    if stack and len(plottables) > 1:
+        from .utils import stack as stack_fun
+
+        plottables = stack_fun(*plottables)
+
+
 class Plottable:
     def __init__(self, values, *, edges=None, variances=None, yerr=None):
         self._values = np.array(values).astype(float)
         self.variances = None
         self._variances = None
+        self._has_variances = False
         if variances is not None:
             self._variances = np.array(variances).astype(float)
             self.variances = np.array(variances).astype(float)
+            self._has_variances = True
         self._density = False
 
         self.values = np.array(values).astype(float)
@@ -221,6 +504,7 @@ class Plottable:
             raise RuntimeError(msg)
         self.yerr_lo = np.nan_to_num(self.yerr_lo, 0)
         self.yerr_hi = np.nan_to_num(self.yerr_hi, 0)
+        self.variances = self.values if not self._has_variances else self.variances
 
     def fixed_errors(self, yerr_lo, yerr_hi):
         self.yerr_lo = yerr_lo


### PR DESCRIPTION
Idea is to have a `get_plottables()` to use internally in the future plothist function. Most of the things that created the `Plottables` in `histplot` have been moved in  `get_plottables()` or to their own little function that `get_plottables()` is calling.
Then, we can create and manage `Plottable` objects, so we can easily remove `boost-histogram` dependency.
The returned `Plottable` objects have a new argument `_has_variances` to store the info if they had variances before the error is automatically calculated when creating the `Plottable` object (before it was only calculated using `.to_errorbar` just before plotting).

This line:
`self.variances = self.values if not self._has_variances else self.variances`
in `Plottable.errors()` is necessary as we query the variances a lot in plothist to compute uncertainties. I have concerns that this line might create problems (e.g. re-weighted histograms) but all the tests are passing for now. We might see differences when using it with plothist examples? maybe `self.variances = self.values if not self.variances else self.variances` is safer?

I'm also not sure about this change in `hist_object_handler()`:
```
    elif isinstance(hist, PlottableHistogram):
        # Before >> msg = "Cannot give bins with existing histogram"
        # Before >> raise TypeError(msg)
        # Now    >> hist_obj = hist
```
I didn't see a reason for this error.

@andrzejnovak @jonas-eschle @cyrraz 