### PR TITLE
chore: update *-artifact GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           python -m pytest -r sa --mpl --mpl-results-path=pytest_results
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: pytest_results-${{ matrix.python-version }}-${{ matrix.runs-on }}

--- a/.github/workflows/head-dependencies.yml
+++ b/.github/workflows/head-dependencies.yml
@@ -43,7 +43,7 @@ jobs:
         pytest -r sa --mpl --mpl-results-path=pytest_results
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: pytest_results-${{ matrix.python-version }}-${{ matrix.runs-on }}
@@ -91,7 +91,7 @@ jobs:
         pytest -r sa --mpl --mpl-results-path=pytest_results
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: pytest_results-${{ matrix.python-version }}-${{ matrix.runs-on }}
@@ -135,7 +135,7 @@ jobs:
         pytest -r sa --mpl --mpl-results-path=pytest_results
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: pytest_results-${{ matrix.python-version }}-${{ matrix.runs-on }}
@@ -179,7 +179,7 @@ jobs:
         pytest -r sa --mpl --mpl-results-path=pytest_results
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: pytest_results-${{ matrix.python-version }}-${{ matrix.runs-on }}


### PR DESCRIPTION
I got a deprecation notice from GitHub, and this is the only still-active Scikit-HEP repo that uses up/download-artifact@v3. So I'm just changing them all to v4. I have two more commits to make.