### PR TITLE
feat!: updating ATLAS color palette to match collboration recommendations

### DIFF
--- a/docs/source/gallery/index.rst
+++ b/docs/source/gallery/index.rst
@@ -32,7 +32,7 @@ Gallery
     #             and s != "LHCb"  # we want LHCb1 or LHCb2
     #     ]
     # the upper one contains all possible styles, needed?
-    allstyle = ["ATLAS", "ATLASAlt", "CMS", "LHCb1", "LHCb2", "ALICE"]
+    allstyle = ["ATLAS1", "ATLAS2", "CMS", "LHCb1", "LHCb2", "ALICE"]
     allstyle = sorted(allstyle, key=lambda s: s.lower())
     # allstyle = sorted(allstyle, key=lambda s: s.lower().endswith("tex"))
     allstyle = sorted(allstyle, key=lambda s: s.lower().endswith("alt"))

--- a/docs/source/gallery/styles.rst
+++ b/docs/source/gallery/styles.rst
@@ -32,16 +32,16 @@ ATLAS has two recommended style. The main recommendation, ``ATLAS``
 in the palette, recommended for signal. In the case of large
 signals, white can also be used.
 
-.. image:: ../../_static/_generated/ATLAS/fill/pos0.png
+.. image:: ../../_static/_generated/ATLAS2/fill/pos0.png
    :width: 45%
 
-.. image:: ../../_static/_generated/ATLAS/step/pos0.png
+.. image:: ../../_static/_generated/ATLAS2/step/pos0.png
     :width: 45%
 
-.. image:: ../../_static/_generated/ATLAS/errorbar/pos0.png
+.. image:: ../../_static/_generated/ATLAS2/errorbar/pos0.png
     :width: 45%
 
-.. image:: ../../_static/_generated/ATLAS/band/pos0.png
+.. image:: ../../_static/_generated/ATLAS2/band/pos0.png
     :width: 45%
 
 For plots that require large numbers of colors, the ``ATLAS1``

--- a/docs/source/gallery/styles.rst
+++ b/docs/source/gallery/styles.rst
@@ -28,7 +28,7 @@ ATLAS
 ------------
 
 ATLAS has two recommended style. The main recommendation, ``ATLAS``
-(or ``ATLAS2``) provides 7 colors, with Vermillion, the first color
+(or ``ATLAS2``) provides 7 colors, with Vermilion, the first color
 in the palette, recommended for signal. In the case of large
 signals, white can also be used.
 

--- a/docs/source/gallery/styles.rst
+++ b/docs/source/gallery/styles.rst
@@ -27,8 +27,7 @@ to illustrate the visual appearance of the styles.
 ATLAS
 ------------
 
-ATLAS has two styles, the default one and the alternative one.
-
+ATLAS has one recommended style, named ``ATLAS`` (or ``ATLAS2``):
 
 .. image:: ../../_static/_generated/ATLAS/fill/pos0.png
    :width: 45%
@@ -42,7 +41,22 @@ ATLAS has two styles, the default one and the alternative one.
 .. image:: ../../_static/_generated/ATLAS/band/pos0.png
     :width: 45%
 
-ATLAS alternative, named ``ATLASAlt``
+Two alternatives are available with different fonts and color
+schemes, named ``ATLAS1`` and ``ATLASAlt``, though these are
+not preferred:
+
+.. image:: ../../_static/_generated/ATLAS1/fill/pos0.png
+   :width: 45%
+
+.. image:: ../../_static/_generated/ATLAS1/step/pos0.png
+    :width: 45%
+
+.. image:: ../../_static/_generated/ATLAS1/errorbar/pos0.png
+    :width: 45%
+
+.. image:: ../../_static/_generated/ATLAS1/band/pos0.png
+    :width: 45%
+
 
 .. image:: ../../_static/_generated/ATLASAlt/fill/pos0.png
    :width: 45%

--- a/docs/source/gallery/styles.rst
+++ b/docs/source/gallery/styles.rst
@@ -31,7 +31,9 @@ ATLAS has one recommended style, named ``ATLAS`` (or ``ATLAS2``).
 The recommended color for signal is ``#ff0000`` (``ROOT.kRed``);
 for large signals, ``#ffffff`` (``ROOT.kWhite``) is also an option.
 In plots without a signal, ``#ff0000`` is intended to be used as
-the last color in the palette.
+the last color in the palette. An ``ATLAS2NoRed`` style is also
+provided for those who would like to separately handle their signal
+histogram.
 
 .. image:: ../../_static/_generated/ATLAS/fill/pos0.png
    :width: 45%

--- a/docs/source/gallery/styles.rst
+++ b/docs/source/gallery/styles.rst
@@ -27,7 +27,11 @@ to illustrate the visual appearance of the styles.
 ATLAS
 ------------
 
-ATLAS has one recommended style, named ``ATLAS`` (or ``ATLAS2``):
+ATLAS has one recommended style, named ``ATLAS`` (or ``ATLAS2``).
+The recommended color for signal is ``#ff0000`` (``ROOT.kRed``);
+for large signals, ``#ffffff`` (``ROOT.kWhite``) is also an option.
+In plots without a signal, ``#ff0000`` is intended to be used as
+the last color in the palette.
 
 .. image:: ../../_static/_generated/ATLAS/fill/pos0.png
    :width: 45%
@@ -39,35 +43,6 @@ ATLAS has one recommended style, named ``ATLAS`` (or ``ATLAS2``):
     :width: 45%
 
 .. image:: ../../_static/_generated/ATLAS/band/pos0.png
-    :width: 45%
-
-Two alternatives are available with different fonts and color
-schemes, named ``ATLAS1`` and ``ATLASAlt``, though these are
-not preferred:
-
-.. image:: ../../_static/_generated/ATLAS1/fill/pos0.png
-   :width: 45%
-
-.. image:: ../../_static/_generated/ATLAS1/step/pos0.png
-    :width: 45%
-
-.. image:: ../../_static/_generated/ATLAS1/errorbar/pos0.png
-    :width: 45%
-
-.. image:: ../../_static/_generated/ATLAS1/band/pos0.png
-    :width: 45%
-
-
-.. image:: ../../_static/_generated/ATLASAlt/fill/pos0.png
-   :width: 45%
-
-.. image:: ../../_static/_generated/ATLASAlt/step/pos0.png
-    :width: 45%
-
-.. image:: ../../_static/_generated/ATLASAlt/errorbar/pos0.png
-    :width: 45%
-
-.. image:: ../../_static/_generated/ATLASAlt/band/pos0.png
     :width: 45%
 
 CMS

--- a/docs/source/gallery/styles.rst
+++ b/docs/source/gallery/styles.rst
@@ -27,13 +27,10 @@ to illustrate the visual appearance of the styles.
 ATLAS
 ------------
 
-ATLAS has one recommended style, named ``ATLAS`` (or ``ATLAS2``).
-The recommended color for signal is ``#ff0000`` (``ROOT.kRed``);
-for large signals, ``#ffffff`` (``ROOT.kWhite``) is also an option.
-In plots without a signal, ``#ff0000`` is intended to be used as
-the last color in the palette. An ``ATLAS2NoRed`` style is also
-provided for those who would like to separately handle their signal
-histogram.
+ATLAS has two recommended style. The main recommendation, ``ATLAS``
+(or ``ATLAS2``) provides 7 colors, with Vermillion, the first color
+in the palette, recommended for signal. In the case of large
+signals, white can also be used.
 
 .. image:: ../../_static/_generated/ATLAS/fill/pos0.png
    :width: 45%
@@ -45,6 +42,21 @@ histogram.
     :width: 45%
 
 .. image:: ../../_static/_generated/ATLAS/band/pos0.png
+    :width: 45%
+
+For plots that require large numbers of colors, the ``ATLAS1``
+palette is provided with 10 colors.
+
+.. image:: ../../_static/_generated/ATLAS1/fill/pos0.png
+   :width: 45%
+
+.. image:: ../../_static/_generated/ATLAS1/step/pos0.png
+    :width: 45%
+
+.. image:: ../../_static/_generated/ATLAS1/errorbar/pos0.png
+    :width: 45%
+
+.. image:: ../../_static/_generated/ATLAS1/band/pos0.png
     :width: 45%
 
 CMS

--- a/docs/source/gallery/styles.rst
+++ b/docs/source/gallery/styles.rst
@@ -27,10 +27,9 @@ to illustrate the visual appearance of the styles.
 ATLAS
 ------------
 
-ATLAS has two recommended style. The main recommendation, ``ATLAS``
-(or ``ATLAS2``) provides 7 colors, with Vermilion, the first color
-in the palette, recommended for signal. In the case of large
-signals, white can also be used.
+ATLAS has two `recommended styles <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PubComPlotStyle#Color_vision_deficiency_palette>`__.
+The main recommendation, ``ATLAS`` (or ``ATLAS2``, based on `this work <https://jfly.uni-koeln.de/color/>`__) provides 7 colors,
+with Vermilion, the first color in the palette, recommended for signal. In the case of large signals, white can also be used.
 
 .. image:: ../../_static/_generated/ATLAS2/fill/pos0.png
    :width: 45%
@@ -44,8 +43,7 @@ signals, white can also be used.
 .. image:: ../../_static/_generated/ATLAS2/band/pos0.png
     :width: 45%
 
-For plots that require large numbers of colors, the ``ATLAS1``
-palette is provided with 10 colors.
+For plots that require large numbers of colors, the ``ATLAS1`` palette is provided with 10 colors `based on this paper <https://arxiv.org/pdf/2107.02270>`__.
 
 .. image:: ../../_static/_generated/ATLAS1/fill/pos0.png
    :width: 45%

--- a/src/mplhep/styles/__init__.py
+++ b/src/mplhep/styles/__init__.py
@@ -8,7 +8,7 @@ import mplhep._deprecate as deprecate
 
 # Short cut to all styles
 from .alice import ALICE
-from .atlas import ATLAS, ATLASAlt, ATLASTex
+from .atlas import ATLAS, ATLAS1, ATLAS2, ATLASAlt, ATLASTex
 from .cms import CMS, ROOT, CMSTex, ROOTTex
 from .lhcb import LHCb, LHCb1, LHCb2, LHCbTex, LHCbTex1, LHCbTex2
 from .plothist import PLOTHIST
@@ -19,6 +19,8 @@ __all__ = (
     "CMS",
     "PLOTHIST",
     "ROOT",
+    "ATLAS1",
+    "ATLAS2",
     "ATLASAlt",
     "ATLASTex",
     "CMSTex",

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -178,8 +178,10 @@ ATLASTex = {k: v for k, v in ATLASTex.items() if k in mpl.rcParams}
 ATLAS = ATLAS2.copy()
 
 # Add warnings for the older sets
-color_msg = ("This ATLAS style uses a color sequence not preferred by the collaboration. "
-             "Please switch to 'ATLAS2' or 'ATLAS' style. ATLAS members can see more at "
-             "https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PubComPlotStyle#Colors")
+color_msg = (
+    "This ATLAS style uses a color sequence not preferred by the collaboration. "
+    "Please switch to 'ATLAS2' or 'ATLAS' style. ATLAS members can see more at "
+    "https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PubComPlotStyle#Colors"
+)
 ATLAS1 = deprecated_dict(ATLAS1, message=color_msg, warning=FutureWarning)
 ATLASAlt = deprecated_dict(ATLASAlt, message=color_msg, warning=FutureWarning)

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -24,13 +24,18 @@ color_sequence1 = [
 
 # Color wheel based on internal discussions of optimal
 # colors for visibility, accounting for color vision deficiency
+# The recommendation for signal is ROOT.kRed aka '#ff0000'; for
+# plots with no signal, '#ff0000' should be used as the final
+# color in the standard palette / color wheel.
+# For large signals, ROOT.kWhite / '#ffffff' is also an option
 color_sequence2 = [
-    "#e69f00",
     "#56b4e9",
-    "#009e73",
+    "#e69f00",
     "#f0e442",
-    "#0072b2",
+    "#009e73",
     "#cc79a7",
+    "#0072b2",
+    "#ff0000",
 ]
 
 _base = {

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -150,6 +150,19 @@ ATLAS2: dict[str, Any] = {
     "mathtext.default": "it",
 }
 
+ATLAS2NoRed: dict[str, Any] = {
+    **_base,
+    "axes.prop_cycle": cycler("color", color_sequence2[0:6]),
+    "mathtext.fontset": "custom",
+    "mathtext.rm": "TeX Gyre Heros",
+    "mathtext.bf": "TeX Gyre Heros:bold",
+    "mathtext.sf": "TeX Gyre Heros",
+    "mathtext.it": "TeX Gyre Heros:italic",
+    "mathtext.tt": "TeX Gyre Heros",
+    "mathtext.cal": "TeX Gyre Heros",
+    "mathtext.default": "it",
+}
+
 # use dejavusans (default math fontset)
 ATLASAlt: dict[str, Any] = {
     **_base,

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -5,18 +5,15 @@ from typing import Any
 import matplotlib as mpl
 from cycler import cycler
 
-# Color wheel from https://arxiv.org/pdf/2107.02270 Table 1, 10 color palette
+# Color wheel based on internal discussions of optimal
+# colors for visibility, accounting for color vision deficiency
 color_sequence = [
-    "#3f90da",
-    "#ffa90e",
-    "#bd1f01",
-    "#94a4a2",
-    "#832db6",
-    "#a96b59",
-    "#e76300",
-    "#b9ac70",
-    "#717581",
-    "#92dadd",
+    "#e69f00",
+    "#56b4e9",
+    "#009e73",
+    "#f0e442",
+    "#0072b2",
+    "#cc79a7",
 ]
 
 _base = {

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -5,6 +5,9 @@ from typing import Any
 import matplotlib as mpl
 from cycler import cycler
 
+# For depreciated colors
+from .._deprecate import deprecated_dict
+
 # Color wheel from https://arxiv.org/pdf/2107.02270 Table 1, 10 color palette
 color_sequence1 = [
     "#3f90da",

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -5,10 +5,9 @@ from typing import Any
 import matplotlib as mpl
 from cycler import cycler
 
-# For depreciated colors
-from .._deprecate import deprecated_dict
-
 # Color wheel from https://arxiv.org/pdf/2107.02270 Table 1, 10 color palette
+# This is the color wheel recommended for plots that require a large number
+# of colors that would not be satisfied by the below palette
 color_sequence1 = [
     "#3f90da",
     "#ffa90e",
@@ -24,18 +23,16 @@ color_sequence1 = [
 
 # Color wheel based on internal discussions of optimal
 # colors for visibility, accounting for color vision deficiency
-# The recommendation for signal is ROOT.kRed aka '#ff0000'; for
-# plots with no signal, '#ff0000' should be used as the final
-# color in the standard palette / color wheel.
+# The recommendation for signal is the first color (Vermillion)
 # For large signals, ROOT.kWhite / '#ffffff' is also an option
 color_sequence2 = [
+    "#d55e00",
     "#56b4e9",
     "#e69f00",
     "#f0e442",
     "#009e73",
     "#cc79a7",
     "#0072b2",
-    "#ff0000",
 ]
 
 _base = {
@@ -150,19 +147,6 @@ ATLAS2: dict[str, Any] = {
     "mathtext.default": "it",
 }
 
-ATLAS2NoRed: dict[str, Any] = {
-    **_base,
-    "axes.prop_cycle": cycler("color", color_sequence2[0:6]),
-    "mathtext.fontset": "custom",
-    "mathtext.rm": "TeX Gyre Heros",
-    "mathtext.bf": "TeX Gyre Heros:bold",
-    "mathtext.sf": "TeX Gyre Heros",
-    "mathtext.it": "TeX Gyre Heros:italic",
-    "mathtext.tt": "TeX Gyre Heros",
-    "mathtext.cal": "TeX Gyre Heros",
-    "mathtext.default": "it",
-}
-
 # use dejavusans (default math fontset)
 ATLASAlt: dict[str, Any] = {
     **_base,
@@ -197,12 +181,3 @@ ATLASTex = {k: v for k, v in ATLASTex.items() if k in mpl.rcParams}
 
 # Alias 'ATLAS' to the one that most folks should use
 ATLAS = ATLAS2.copy()
-
-# Add warnings for the older sets
-color_msg = (
-    "This ATLAS style uses a color sequence not preferred by the collaboration. "
-    "Please switch to 'ATLAS2' or 'ATLAS' style. ATLAS members can see more at "
-    "https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PubComPlotStyle#Colors"
-)
-ATLAS1 = deprecated_dict(ATLAS1, message=color_msg, warning=FutureWarning)
-ATLASAlt = deprecated_dict(ATLASAlt, message=color_msg, warning=FutureWarning)

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -178,8 +178,8 @@ ATLASTex = {k: v for k, v in ATLASTex.items() if k in mpl.rcParams}
 ATLAS = ATLAS2.copy()
 
 # Add warnings for the older sets
-color_msg = ("This ATLAS style uses a color sequence not preferred by the collaboration.
-              Please switch to 'ATLAS2' or 'ATLAS' style. ATLAS members can see more at
-              https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PubComPlotStyle#Colors")
+color_msg = ("This ATLAS style uses a color sequence not preferred by the collaboration. "
+             "Please switch to 'ATLAS2' or 'ATLAS' style. ATLAS members can see more at "
+             "https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PubComPlotStyle#Colors")
 ATLAS1 = deprecated_dict(ATLAS1, message=color_msg, warning=FutureWarning)
 ATLASAlt = deprecated_dict(ATLASAlt, message=color_msg, warning=FutureWarning)

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -23,7 +23,7 @@ color_sequence1 = [
 
 # Color wheel based on internal discussions of optimal
 # colors for visibility, accounting for color vision deficiency
-# The recommendation for signal is the first color (Vermillion)
+# The recommendation for signal is the first color (Vermilion)
 # For large signals, ROOT.kWhite / '#ffffff' is also an option
 color_sequence2 = [
     "#d55e00",

--- a/src/mplhep/styles/atlas.py
+++ b/src/mplhep/styles/atlas.py
@@ -5,9 +5,23 @@ from typing import Any
 import matplotlib as mpl
 from cycler import cycler
 
+# Color wheel from https://arxiv.org/pdf/2107.02270 Table 1, 10 color palette
+color_sequence1 = [
+    "#3f90da",
+    "#ffa90e",
+    "#bd1f01",
+    "#94a4a2",
+    "#832db6",
+    "#a96b59",
+    "#e76300",
+    "#b9ac70",
+    "#717581",
+    "#92dadd",
+]
+
 # Color wheel based on internal discussions of optimal
 # colors for visibility, accounting for color vision deficiency
-color_sequence = [
+color_sequence2 = [
     "#e69f00",
     "#56b4e9",
     "#009e73",
@@ -46,7 +60,6 @@ _base = {
     "figure.subplot.left": 0.16,
     "figure.subplot.right": 0.95,
     # axes
-    "axes.prop_cycle": cycler("color", color_sequence),
     "axes.titlesize": "xx-large",
     "axes.labelsize": "x-large",
     "axes.linewidth": 1,
@@ -103,8 +116,22 @@ _base = {
     "savefig.transparent": False,
 }
 
-ATLAS: dict[str, Any] = {
+ATLAS1: dict[str, Any] = {
     **_base,
+    "axes.prop_cycle": cycler("color", color_sequence1),
+    "mathtext.fontset": "custom",
+    "mathtext.rm": "TeX Gyre Heros",
+    "mathtext.bf": "TeX Gyre Heros:bold",
+    "mathtext.sf": "TeX Gyre Heros",
+    "mathtext.it": "TeX Gyre Heros:italic",
+    "mathtext.tt": "TeX Gyre Heros",
+    "mathtext.cal": "TeX Gyre Heros",
+    "mathtext.default": "it",
+}
+
+ATLAS2: dict[str, Any] = {
+    **_base,
+    "axes.prop_cycle": cycler("color", color_sequence2),
     "mathtext.fontset": "custom",
     "mathtext.rm": "TeX Gyre Heros",
     "mathtext.bf": "TeX Gyre Heros:bold",
@@ -118,12 +145,13 @@ ATLAS: dict[str, Any] = {
 # use dejavusans (default math fontset)
 ATLASAlt: dict[str, Any] = {
     **_base,
+    "axes.prop_cycle": cycler("color", color_sequence1),
     "mathtext.default": "it",
 }
 
 # use LaTeX
 ATLASTex: dict[str, Any] = {
-    **_base,
+    **ATLAS2,
     "text.usetex": True,
     "text.latex.preamble": "\n".join(
         [
@@ -141,6 +169,17 @@ ATLASTex: dict[str, Any] = {
 }
 
 # Filter extra (labellocation) items if needed
-ATLAS = {k: v for k, v in ATLAS.items() if k in mpl.rcParams}
+ATLAS1 = {k: v for k, v in ATLAS1.items() if k in mpl.rcParams}
+ATLAS2 = {k: v for k, v in ATLAS2.items() if k in mpl.rcParams}
 ATLASAlt = {k: v for k, v in ATLASAlt.items() if k in mpl.rcParams}
 ATLASTex = {k: v for k, v in ATLASTex.items() if k in mpl.rcParams}
+
+# Alias 'ATLAS' to the one that most folks should use
+ATLAS = ATLAS2.copy()
+
+# Add warnings for the older sets
+color_msg = ("This ATLAS style uses a color sequence not preferred by the collaboration.
+              Please switch to 'ATLAS2' or 'ATLAS' style. ATLAS members can see more at
+              https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PubComPlotStyle#Colors")
+ATLAS1 = deprecated_dict(ATLAS1, message=color_msg, warning=FutureWarning)
+ATLASAlt = deprecated_dict(ATLASAlt, message=color_msg, warning=FutureWarning)


### PR DESCRIPTION
After an internal working group to discuss color palette options and color-vision deficiency of various kinds, these are the proposed colors that the experiment will adopt.

The plan is to announce this next week, and so it'd be great to have this in place by then.

Thanks,
Zach