### PR TITLE
chore: classifiers should not be present with SPDX license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 classifiers = [
     "Framework :: Matplotlib",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This should be producing a warning when building, at least (flit-core makes it an error, I think).
