### PR TITLE
fix: deploy mike-built docs via actions/deploy-pages

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -23,6 +23,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,21 +72,25 @@ jobs:
           # Extract version from tag (v1.2.3 -> 1.2)
           VERSION=$(echo "${GITHUB_REF#refs/tags/v}" | cut -d. -f1,2)
           mike deploy --update-aliases "$VERSION" latest
-          mike set-default latest
 
       - name: Export site from local gh-pages branch
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: |
-          git checkout gh-pages -- .
-          rm -rf .git
+          git worktree add _gh-pages gh-pages
+          rm -rf _gh-pages/.git
 
       - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-pages-artifact@v3
         with:
-          path: .
+          path: _gh-pages
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- The docs deployment workflow used `mike --push` to the `gh-pages` branch, but GitHub Pages was configured for workflow-based (`actions/deploy-pages`) deployment. This caused the deployed site at `scikit-hep.org/mplhep` to be stale, missing the dark mode logo CSS from #684.
- Now mike builds locally on the CI runner (no `--push`), then the site is uploaded as a Pages artifact and deployed via `actions/deploy-pages`.
- Sets `dev` as the default mike version so the root URL redirects to `/dev/`.

## Test plan
- [ ] Verify CI workflow passes
- [ ] Verify `scikit-hep.org/mplhep/` redirects to `/dev/`
- [ ] Verify dark mode logo inversion works on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)