### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -46,7 +46,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           activate-environment: true
           version: "latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           activate-environment: true
           version: "latest"

--- a/.github/workflows/ci_latex.yml
+++ b/.github/workflows/ci_latex.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           activate-environment: true
           version: 'latest'

--- a/.github/workflows/head-dependencies.yml
+++ b/.github/workflows/head-dependencies.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
       with:
         activate-environment: true
         version: "latest"
@@ -70,7 +70,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
       with:
         activate-environment: true
         version: "latest"
@@ -128,7 +128,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
       with:
         activate-environment: true
         version: "latest"
@@ -182,7 +182,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
       with:
         activate-environment: true
         version: "latest"


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos