### PR TITLE
feat: drop Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ ubuntu-latest ]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:  # testing the last "reasonable supported" version
           - runs-on: macOS-15-intel
-            python-version: "3.9"
+            python-version: "3.10"
           - runs-on: macOS-latest
-            python-version: "3.9"
+            python-version: "3.10"
           - runs-on: windows-latest
-            python-version: "3.9"
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v6

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.sessions = ["lint", "tests"]
 nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv|venv"
 
-PYTHON_ALL_VERSIONS = ["3.9", "3.13"]
+PYTHON_ALL_VERSIONS = ["3.10", "3.13"]
 
 
 @nox.session(reuse_venv=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.sessions = ["lint", "tests"]
 nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv|venv"
 
-PYTHON_ALL_VERSIONS = ["3.10", "3.13"]
+PYTHON_ALL_VERSIONS = ["3.10", "3.14"]
 
 
 @nox.session(reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Matplotlib styles for HEP"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "andrzejnovak", email = "novak5andrzej@gmail.com" },
 ]
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -26,12 +25,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
-    "matplotlib>=3.4,<3.10; python_version < '3.10'",
-    "matplotlib>=3.10.8; python_version >= '3.10'",
+    "matplotlib>=3.10.8",
     "mplhep-data>=0.0.4",
     "numpy>=1.16.0",
     "packaging",
-    "pyparsing<3.3.0; python_version < '3.10'",  # Avoid oneOf deprecation warning with older matplotlib
     "uhi>=0.2.0",
 ]
 
@@ -149,6 +146,7 @@ markers = [
 
 
 [tool.ruff]
+target-version = "py310"
 show-fixes = true
 
 [tool.ruff.lint]

--- a/src/mplhep/_compat.py
+++ b/src/mplhep/_compat.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
-import sys
-from typing import Any, Callable, TypeVar
-
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec, TypeAlias
-else:
-    from typing_extensions import ParamSpec, TypeAlias
+from collections.abc import Callable
+from typing import Any, ParamSpec, TypeAlias, TypeVar
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/src/mplhep/_utils.py
+++ b/src/mplhep/_utils.py
@@ -270,7 +270,7 @@ def _get_plottables(
         xoffsets = parsed_offsets
     else:
         xoffsets = [None] * len(hists)
-    for h, xoffset in zip(hists, xoffsets):
+    for h, xoffset in zip(hists, xoffsets, strict=True):
         value, variance = np.copy(h.values()), h.variances()
         if has_variances := variance is not None:
             variance = np.copy(variance)
@@ -379,7 +379,9 @@ def _get_plottables(
 
     if w2 is not None:
         for _w2, _plottable in zip(
-            np.array(w2).reshape(len(plottables), len(final_bins) - 1), plottables
+            np.array(w2).reshape(len(plottables), len(final_bins) - 1),
+            plottables,
+            strict=True,
         ):
             _plottable.set_variances(_w2)
             _plottable.method = w2method
@@ -462,7 +464,7 @@ def _yerr_plottables(plottables, bins, yerr=None):
             raise ValueError(msg)
 
         assert _yerr is not None
-        for yrs, _plottable in zip(_yerr, plottables):
+        for yrs, _plottable in zip(_yerr, plottables, strict=True):
             _plottable.fixed_errors(*yrs)
 
 
@@ -514,7 +516,7 @@ def _norm_stack_plottables(plottables, bins, stack=False, density=False, binwnor
                 plottable.density()
     elif binwnorm is not None:
         for plottable, norm in zip(
-            plottables, np.broadcast_to(binwnorm, (len(plottables),))
+            plottables, np.broadcast_to(binwnorm, (len(plottables),)), strict=True
         ):
             plottable.flat_scale(norm)
             plottable.binwnorm()

--- a/src/mplhep/error_estimation.py
+++ b/src/mplhep/error_estimation.py
@@ -42,7 +42,10 @@ def poisson_interval(sumw, sumw2, coverage=_coverage1sd):
             )
             return np.vstack([sumw, sumw])
         nearest = np.sum(
-            [np.subtract.outer(d, d0) ** 2 for d, d0 in zip(available, missing)]
+            [
+                np.subtract.outer(d, d0) ** 2
+                for d, d0 in zip(available, missing, strict=True)
+            ]
         ).argmin(axis=0)
         argnearest = tuple(dim[nearest] for dim in available)
         scale[missing] = scale[argnearest]

--- a/src/mplhep/label.py
+++ b/src/mplhep/label.py
@@ -1110,7 +1110,7 @@ def save_variations(
         for ax in fig.get_axes():
             exp_labels = [t for t in ax.get_children() if isinstance(t, ExpText)]
             suffixes = [t for t in ax.get_children() if isinstance(t, ExpText)]
-            for exp_label, suffix_text in zip(exp_labels, suffixes):
+            for exp_label, suffix_text in zip(exp_labels, suffixes, strict=True):
                 if exp is not None:
                     exp_label.set_text(exp)
                 suffix_text.set_text(text)

--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections.abc
 import inspect
 import logging
-from typing import TYPE_CHECKING, Any, NamedTuple, Union
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -68,7 +68,7 @@ class ColormeshArtists(NamedTuple):
     text: Any
 
 
-Hist1DArtists = Union[StairsArtists, ErrorBarArtists]
+Hist1DArtists = StairsArtists | ErrorBarArtists
 Hist2DArtists = ColormeshArtists
 
 
@@ -1527,6 +1527,7 @@ def model(
             unstacked_colors,
             unstacked_labels,
             unstacked_kwargs_list,
+            strict=True,
         ):
             if model_type == "histograms":
                 unstacked_kwargs.setdefault("histtype", "step")

--- a/src/mplhep/plot_comp.py
+++ b/src/mplhep/plot_comp.py
@@ -508,6 +508,7 @@ def model(
             unstacked_colors,
             unstacked_labels,
             unstacked_kwargs_list,
+            strict=True,
         ):
             if model_type == "histograms":
                 unstacked_kwargs.setdefault("histtype", "step")

--- a/src/mplhep/utils.py
+++ b/src/mplhep/utils.py
@@ -38,7 +38,7 @@ def merge_legend_handles_labels(handles, labels):
 
     seen_labels = []
     seen_label_handles = []
-    for handle, label in zip(handles, labels):
+    for handle, label in zip(handles, labels, strict=True):
         if label not in seen_labels:
             seen_labels.append(label)
             seen_label_handles.append([handle])
@@ -565,7 +565,7 @@ def sort_legend(ax, order=None):
     """
 
     handles, labels = ax.get_legend_handles_labels()
-    by_label = OrderedDict(zip(labels, handles))
+    by_label = OrderedDict(zip(labels, handles, strict=True))
 
     if isinstance(order, OrderedDict):
         ordered_label_list = list(order.keys())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -705,7 +705,9 @@ def test_histplot_w2_methods():
         ) * 0.2 * np.mean(w)
 
     fig, axs = plt.subplots(2, 3, figsize=(12, 8))
-    for ax, method in zip(axs.flatten(), [None, "poisson", "sqrt", fcn1, fcn2]):
+    for ax, method in zip(
+        axs.flatten(), [None, "poisson", "sqrt", fcn1, fcn2], strict=False
+    ):
         mh.histplot(htype1, w2=htype1_w2, w2method=method, ax=ax, label="With w2")
         mh.histplot(htype1, w2method=method, ax=ax, label="No w2 passed")
         htype2.plot(w2method=method, ax=ax, label="Hist")

--- a/tests/test_comparison_flow.py
+++ b/tests/test_comparison_flow.py
@@ -32,7 +32,7 @@ def test_comparison_flow():
     flow_options = ["hint", "show", "sum", "none"]
     titles = ["Default(hint)", "Show", "Sum", "None"]
 
-    for idx, (flow_opt, title) in enumerate(zip(flow_options, titles)):
+    for idx, (flow_opt, title) in enumerate(zip(flow_options, titles, strict=True)):
         row_offset = (idx // 2) * 2  # 0 for first two, 2 for last two
         col = idx % 2
 

--- a/tests/test_comparison_low_count.py
+++ b/tests/test_comparison_low_count.py
@@ -82,7 +82,7 @@ def test_low_count_comparisons_defaults():
     h_data, h_model = _make_low_count_hists()
     n = len(COMPARISONS)
     fig, axes = plt.subplots(n, 1, figsize=(8, 3 * n))
-    for ax, comp_type in zip(axes, COMPARISONS):
+    for ax, comp_type in zip(axes, COMPARISONS, strict=True):
         comparison(
             h_data,
             h_model,

--- a/tests/test_hists_flow.py
+++ b/tests/test_hists_flow.py
@@ -31,7 +31,7 @@ def test_hists_flow():
     flow_options = ["hint", "show", "sum", "none"]
     titles = ["Default(hint)", "Show", "Sum", "None"]
 
-    for idx, (flow_opt, title) in enumerate(zip(flow_options, titles)):
+    for idx, (flow_opt, title) in enumerate(zip(flow_options, titles, strict=True)):
         row_offset = (idx // 2) * 2  # 0 for first two, 2 for last two
         col = idx % 2
 

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -163,7 +163,7 @@ def test_append_text_placement(fontname):
         # Use original labeling pattern to match baseline images
         labels = ["1", "2", "2", "1"]  # Original pattern from t1, t2, t3, t4
         for _, (text_obj, font_size, label_prefix) in enumerate(
-            zip(texts, font_sizes, labels)
+            zip(texts, font_sizes, labels, strict=True)
         ):
             label = f"{label_prefix}-{app_pos}"
             mh.append_text(label, text_obj, fontsize=font_size, **append_kwargs)

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -341,7 +341,7 @@ def test_cms_label_gap_is_dpi_invariant():
     # All measured gaps should be identical in inches (constant physical
     # size). Half a hundredth-of-an-inch tolerance for sub-pixel rounding.
     ref = gaps_in_inches[0]
-    for dpi, gap in zip((50, 100, 200, 300), gaps_in_inches):
+    for dpi, gap in zip((50, 100, 200, 300), gaps_in_inches, strict=True):
         assert abs(gap - ref) < 5e-3, (
             f"Gap at dpi={dpi} is {gap:.4f}in but at dpi=50 is {ref:.4f}in -- "
             f"label positioning is not DPI-invariant. All gaps: {gaps_in_inches}"


### PR DESCRIPTION
Dropping python 3.9 since it's not supported anymore. 

🤖 Assisted-by: Claude Sonnet 4.5 and this nice [SKILL.md](https://github.com/henryiii/skills/blob/main/drop-python39/SKILL.md).