### PR TITLE
fix: histplot/hist argument handling (sort, yerr, xerr, weights)

### DIFF
--- a/src/mplhep/plot.py
+++ b/src/mplhep/plot.py
@@ -210,12 +210,21 @@ def hist(
         else:
             bin_edges = np.asarray(bins)
 
+        # Determine whether weights are shared across datasets or given
+        # per-dataset (a list/tuple of weight arrays, like plt.hist accepts).
+        per_dataset_weights = isinstance(weights, (list, tuple))
+
         # Histogram each dataset
         hist_values = []
         hist_w2 = []
-        for dataset in datasets:
+        for i, dataset in enumerate(datasets):
             data_arr = np.asarray(dataset).ravel()
-            w = None if weights is None else np.asarray(weights).ravel()
+            if weights is None:
+                w = None
+            elif per_dataset_weights:
+                w = np.asarray(weights[i]).ravel()
+            else:
+                w = np.asarray(weights).ravel()
 
             h, _ = np.histogram(data_arr, bins=bin_edges, weights=w, density=False)
             hist_values.append(h)
@@ -229,9 +238,13 @@ def hist(
 
         # Pass to histplot
         w2_arg = hist_w2 if weights is not None and len(hist_w2) > 0 else None
+        # If errors are explicitly disabled, don't supply w2 either (otherwise
+        # histplot would still draw uncertainties from the variances).
+        if yerr is False:
+            w2_arg = None
         # If w2 is provided, don't pass yerr (w2 will be used for error calculation)
         # If yerr is explicitly an array, still pass it
-        yerr_arg = None if w2_arg is not None and isinstance(yerr, bool) else yerr
+        yerr_arg = None if w2_arg is not None and yerr is True else yerr
         return histplot(
             hist_values,
             bin_edges,
@@ -263,9 +276,13 @@ def hist(
         h_w2, _ = np.histogram(x, bins=bin_edges, weights=w**2, density=False)
         w2_arg = h_w2
 
+    # If errors are explicitly disabled, don't supply w2 either (otherwise
+    # histplot would still draw uncertainties from the variances).
+    if yerr is False:
+        w2_arg = None
     # If w2 is provided, don't pass yerr (w2 will be used for error calculation)
     # If yerr is explicitly an array, still pass it
-    yerr_arg = None if w2_arg is not None and isinstance(yerr, bool) else yerr
+    yerr_arg = None if w2_arg is not None and yerr is True else yerr
 
     # Pass to histplot
     return histplot(
@@ -491,11 +508,16 @@ def histplot(
     # Sorting
     if sort is not None:
         if isinstance(sort, str):
-            if sort.split("_")[0] in ["l", "label"] and isinstance(_labels, list):
-                order = np.argsort(label)  # [::-1]
+            if sort.split("_")[0] in ["l", "label"]:
+                # Sort on the normalized labels; use string keys so that
+                # ``None`` labels (unlabelled hists) compare safely.
+                order = np.argsort([str(_l) for _l in _labels])  # [::-1]
             elif sort.split("_")[0] in ["y", "yield"]:
                 _yields = [np.sum(_h.values()) for _h in hists]  # type: ignore[var-annotated]
                 order = np.argsort(_yields)
+            else:
+                msg = f"Sort type: {sort} not understood."
+                raise ValueError(msg)
             if len(sort.split("_")) == 2 and sort.split("_")[1] == "r":
                 order = order[::-1]
         elif isinstance(sort, (list, np.ndarray)):
@@ -738,21 +760,12 @@ def histplot(
             "elinewidth": 1,
         }
 
-        _xerr: np.ndarray | float | int | None
-
-        if xerr is True:
-            _xerr = _bin_widths / 2
-        elif isinstance(xerr, (int, float)) and not isinstance(xerr, bool):
-            _xerr = xerr
-        else:
-            _xerr = None
-
         for i in range(len(plottables)):
             _kwargs = _chunked_kwargs[i]
             _plot_info = plottables[i].to_errorbar()
             if yerr is False:
                 _plot_info["yerr"] = None
-            if not xerr:
+            if xerr is None or xerr is False:
                 del _plot_info["xerr"]
             if isinstance(xerr, (int, float)) and not isinstance(xerr, bool):
                 _plot_info["xerr"] = xerr

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -807,6 +807,118 @@ def test_histplot_inputs_pass(h, yerr, htype):
     plt.close(fig)
 
 
+@pytest.mark.parametrize("label", ["data", None])
+def test_histplot_sort_label_keeps_all_hists(label):
+    # Regression: sort="label" with a scalar/None label used to argsort the raw
+    # `label` argument, dropping all but one histogram.
+    bins = np.linspace(0, 10, 11)
+    h = np.arange(10).astype(float)
+
+    fig, ax = plt.subplots()
+    artists = mh.histplot([h, 2 * h, 3 * h], bins, label=label, sort="label", ax=ax)
+    assert len(artists) == 3
+    plt.close(fig)
+
+
+def test_histplot_sort_label_orders_by_label():
+    # sort="label" should order histograms by their (normalized) labels.
+    bins = np.linspace(0, 10, 11)
+    h = np.arange(10).astype(float)
+
+    fig, ax = plt.subplots()
+    artists = mh.histplot(
+        [3 * h, h, 2 * h], bins, label=["c", "a", "b"], sort="label", ax=ax
+    )
+    labels = [a.stairs.get_label() for a in artists]
+    assert labels == ["a", "b", "c"]
+    plt.close(fig)
+
+
+def test_histplot_sort_unknown_raises():
+    # Regression: an unknown sort string used to raise UnboundLocalError; it
+    # should raise a clear ValueError instead.
+    bins = np.linspace(0, 10, 11)
+    h = np.arange(10).astype(float)
+
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match="Sort type"):
+        mh.histplot([h, 2 * h], bins, sort="foo", ax=ax)
+    plt.close(fig)
+
+
+def test_hist_yerr_false_with_weights_no_errorbars():
+    # Regression: hist(..., weights=w, yerr=False) used to draw error bars
+    # anyway because yerr=False was converted to None alongside w2.
+    np.random.seed(0)
+    bins = np.linspace(0, 10, 11)
+    data = np.random.normal(5, 2, 1000)
+    weights = np.random.uniform(0.5, 1.5, 1000)
+
+    fig, ax = plt.subplots()
+    artists = mh.hist(
+        data, bins=bins, weights=weights, yerr=False, histtype="errorbar", ax=ax
+    )
+    # errorbar container: index 2 holds the (y)error LineCollections
+    assert artists[0].errorbar[2] == ()
+
+    # Sanity: yerr=True still produces error bars.
+    fig2, ax2 = plt.subplots()
+    artists_true = mh.hist(
+        data, bins=bins, weights=weights, yerr=True, histtype="errorbar", ax=ax2
+    )
+    assert len(artists_true[0].errorbar[2]) > 0
+    plt.close(fig)
+    plt.close(fig2)
+
+
+def test_histplot_errorbar_ndarray_xerr():
+    # Regression: ndarray xerr used to raise "truth value of an array is
+    # ambiguous" while equivalent lists worked.
+    bins = np.linspace(0, 10, 11)
+    h = np.arange(10).astype(float)
+    xerr = np.tile(np.full(10, 0.3), (2, 1))
+
+    fig, ax = plt.subplots()
+    artists = mh.histplot([h, 2 * h], bins, histtype="errorbar", xerr=xerr, ax=ax)
+    assert len(artists) == 2
+
+    # List xerr (and True/scalar) must keep working.
+    fig2, ax2 = plt.subplots()
+    artists_list = mh.histplot(
+        [h, 2 * h],
+        bins,
+        histtype="errorbar",
+        xerr=[np.full(10, 0.3), np.full(10, 0.3)],
+        ax=ax2,
+    )
+    assert len(artists_list) == 2
+    plt.close(fig)
+    plt.close(fig2)
+
+
+def test_hist_multidataset_weights():
+    # Regression: multi-dataset hist() flattened the entire weights structure
+    # for every dataset, so plt.hist-style per-dataset weights always failed.
+    np.random.seed(0)
+    bins = np.linspace(0, 10, 11)
+    d1 = np.random.normal(5, 2, 1000)
+    d2 = np.random.normal(6, 2, 800)
+    w1 = np.random.uniform(0.5, 1.5, 1000)
+    w2 = np.random.uniform(0.5, 1.5, 800)
+
+    # Per-dataset list of weight arrays (plt.hist style).
+    fig, ax = plt.subplots()
+    artists = mh.hist([d1, d2], bins=bins, weights=[w1, w2], ax=ax)
+    assert len(artists) == 2
+    plt.close(fig)
+
+    # A single shared weights array (matching dataset shapes) still works.
+    fig2, ax2 = plt.subplots()
+    artists_shared = mh.hist([d1, d1], bins=bins, weights=w1, ax=ax2)
+    assert len(artists_shared) == 2
+    plt.close(fig2)
+
+
 @pytest.mark.parametrize(
     "sort", [None, "label", "label_r", "yield", "yield_r", [0, 2, 1]]
 )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #731.

Fixes four verified argument-handling bugs in `src/mplhep/plot.py`, each with a plain (non-image) regression test in `tests/test_basic.py`.

### Bug A — `histplot(..., sort="label")` silently dropped histograms
The sort code argsorted the **raw** `label` argument instead of the normalized `_labels` list. With a scalar `label="data"` or `label=None`, `np.argsort` returned `[0]` and the subsequent indexing kept only one histogram. Now it argsorts the normalized labels (stringified so `None` labels compare safely). Additionally, an unknown sort string (e.g. `sort="foo"`) fell through both branches leaving `order` unbound (`UnboundLocalError`); it now raises a clear `ValueError("Sort type ... not understood")`. The always-true `isinstance(_labels, list)` guard was removed.

### Bug B — `hist(..., weights=w, yerr=False)` drew error bars anyway
`yerr_arg = None if w2_arg is not None and isinstance(yerr, bool) else yerr` converted **both** `True` and `False` to `None`, so `yerr=False` with weights still produced errors. Now only `yerr is True` is converted, and `yerr=False` additionally drops `w2` so no uncertainties are computed or drawn (this also avoids the `get_plottables` "Can only supply errors or w2" guard). Fixed in both the single- and multi-dataset paths.

### Bug C — `histtype="errorbar"` with ndarray `xerr` crashed
`if not xerr:` raised "truth value of an array is ambiguous" for multi-element numpy arrays (lists worked). The condition is now `if xerr is None or xerr is False:`, preserving the existing list/scalar/`True` behavior. The dead `_xerr` computation (assigned but never read) was removed.

### Bug D — multi-dataset `hist()` weights always failed
In the multi-dataset loop, `np.asarray(weights).ravel()` flattened the **entire** weights structure for every dataset, so `plt.hist`-style list-of-weight-arrays raised `ValueError: weights should have the same shape as a`. Weights are now indexed per dataset, supporting both a single shared array and a per-dataset list (matching `plt.hist`).

### Testing
- Added 7 regression tests covering all four bugs (plain artist-count / raises / label-order / no-errorbar assertions).
- Full suite: `uv run pytest -r sa --mpl -n 4 --ignore=tests/test_notebooks.py` → 290 passed, 74 skipped (Linux-only / missing ROOT, pre-existing). No baseline images changed; no tolerances touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)