### PR TITLE
fix(test): drop deprecated numpy chararray to fix HEAD-of-deps CI

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,13 +13,6 @@ import uproot
 
 os.environ["RUNNING_PYTEST"] = "true"
 
-try:
-    # NumPy 2
-    from numpy.char import chararray
-except ModuleNotFoundError:
-    # NumPy 1
-    from numpy import chararray
-
 import mplhep as mh
 
 # Import benchmark decorator from helpers
@@ -550,12 +543,10 @@ def test_hist2dplot_labels_option():
 
     assert mh.hist2dplot(H, xedges, yedges, labels=False)
 
-    label_array = chararray(H.shape, itemsize=2)
-    label_array[:] = "hi"
+    label_array = np.full(H.shape, "hi", dtype="U2")
     assert mh.hist2dplot(H, xedges, yedges, labels=label_array)
 
-    label_array = chararray(H.shape[0], itemsize=2)
-    label_array[:] = "hi"
+    label_array = np.full(H.shape[0], "hi", dtype="U2")
     # Label array shape invalid
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
## Problem

The **HEAD of dependencies** workflow has been red, but it's **not** the matplotlib 3.11 changes — that fix (#730) works fine; the nightly job even reports `Matplotlib: 3.11.0` and gets past import.

The real cause is **NumPy nightly**. Collection of `tests/test_basic.py` fails before any test runs:

```
tests/test_basic.py:18: in <module>
    from numpy.char import chararray
E   DeprecationWarning: The chararray class is deprecated and will be removed
    in a future release. Use an ndarray with a string or bytes dtype instead.
!!!!! Interrupted: 1 error during collection !!!!!
Process completed with exit code 2.
```

Chain of events:
1. NumPy nightly emits a `DeprecationWarning` on `from numpy.char import chararray`.
2. `pyproject.toml` sets `filterwarnings = ["error"]`, promoting it to a hard error.
3. It fires at import time, so the whole module fails to collect → exit code 2 → red job.

The pre-existing `try/except` only caught `ModuleNotFoundError`, so the warning-as-error slipped through. This is why the `matplotlib` and `release-candidates` jobs (which pull nightly/pre-release NumPy) fail, while `uhi` and `pytest` (released NumPy) pass.

## Fix

Drop the deprecated `chararray` entirely and build the label arrays as plain string-dtype ndarrays:

```python
label_array = np.full(H.shape, "hi", dtype="U2")
```

This exercises `hist2dplot` label arrays identically. Test-only change; no baselines affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)