### PR TITLE
ci: fail loudly when core fonts are missing after install

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -55,11 +55,16 @@ jobs:
 
       - name: Install core fonts
         run: |
+          set -euo pipefail
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get install ttf-mscorefonts-installer
-
-      - name: List available fonts
-        run: fc-list | grep -i microsoft || fc-list | grep -i "times new" || echo "Microsoft fonts listing complete"
+          sudo apt-get update -y
+          sudo apt-get install -y ttf-mscorefonts-installer
+          fc-cache -fv
+          if ! fc-list | grep -qi "times new roman"; then
+            echo "ERROR: Times New Roman font not found after installation." >&2
+            exit 1
+          fi
+          echo "Times New Roman font verified successfully."
 
       - name: Install package and documentation dependencies
         run: |

--- a/.github/workflows/ci_latex.yml
+++ b/.github/workflows/ci_latex.yml
@@ -58,11 +58,16 @@ jobs:
 
       - name: Install core fonts
         run: |
+          set -euo pipefail
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get install ttf-mscorefonts-installer
-
-      - name: List available fonts
-        run: fc-list | grep -i microsoft || fc-list | grep -i "times new" || echo "Microsoft fonts listing complete"
+          sudo apt-get update -y
+          sudo apt-get install -y ttf-mscorefonts-installer
+          fc-cache -fv
+          if ! fc-list | grep -qi "times new roman"; then
+            echo "ERROR: Times New Roman font not found after installation." >&2
+            exit 1
+          fi
+          echo "Times New Roman font verified successfully."
 
       - name: Install LaTeX packages
         run: |

--- a/.github/workflows/head-dependencies.yml
+++ b/.github/workflows/head-dependencies.yml
@@ -31,12 +31,16 @@ jobs:
     - name: Install core fonts
       if: runner.os == 'Linux'
       run: |
+        set -euo pipefail
         echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-        sudo apt-get install ttf-mscorefonts-installer
-
-    - name: List available fonts
-      if: runner.os == 'Linux'
-      run: fc-list | grep -i microsoft || fc-list | grep -i "times new" || echo "Microsoft fonts listing complete"
+        sudo apt-get update -y
+        sudo apt-get install -y ttf-mscorefonts-installer
+        fc-cache -fv
+        if ! fc-list | grep -qi "times new roman"; then
+          echo "ERROR: Times New Roman font not found after installation." >&2
+          exit 1
+        fi
+        echo "Times New Roman font verified successfully."
 
     - name: Install dependencies
       run: |
@@ -83,12 +87,16 @@ jobs:
     - name: Install core fonts
       if: runner.os == 'Linux'
       run: |
+        set -euo pipefail
         echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-        sudo apt-get install ttf-mscorefonts-installer
-
-    - name: List available fonts
-      if: runner.os == 'Linux'
-      run: fc-list | grep -i microsoft || fc-list | grep -i "times new" || echo "Microsoft fonts listing complete"
+        sudo apt-get update -y
+        sudo apt-get install -y ttf-mscorefonts-installer
+        fc-cache -fv
+        if ! fc-list | grep -qi "times new roman"; then
+          echo "ERROR: Times New Roman font not found after installation." >&2
+          exit 1
+        fi
+        echo "Times New Roman font verified successfully."
 
     - name: Install dependencies
       run: |
@@ -141,12 +149,16 @@ jobs:
     - name: Install core fonts
       if: runner.os == 'Linux'
       run: |
+        set -euo pipefail
         echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-        sudo apt-get install ttf-mscorefonts-installer
-
-    - name: List available fonts
-      if: runner.os == 'Linux'
-      run: fc-list | grep -i microsoft || fc-list | grep -i "times new" || echo "Microsoft fonts listing complete"
+        sudo apt-get update -y
+        sudo apt-get install -y ttf-mscorefonts-installer
+        fc-cache -fv
+        if ! fc-list | grep -qi "times new roman"; then
+          echo "ERROR: Times New Roman font not found after installation." >&2
+          exit 1
+        fi
+        echo "Times New Roman font verified successfully."
 
     - name: Install dependencies
       run: |
@@ -195,12 +207,16 @@ jobs:
     - name: Install core fonts
       if: runner.os == 'Linux'
       run: |
+        set -euo pipefail
         echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-        sudo apt-get install ttf-mscorefonts-installer
-
-    - name: List available fonts
-      if: runner.os == 'Linux'
-      run: fc-list | grep -i microsoft || fc-list | grep -i "times new" || echo "Microsoft fonts listing complete"
+        sudo apt-get update -y
+        sudo apt-get install -y ttf-mscorefonts-installer
+        fc-cache -fv
+        if ! fc-list | grep -qi "times new roman"; then
+          echo "ERROR: Times New Roman font not found after installation." >&2
+          exit 1
+        fi
+        echo "Times New Roman font verified successfully."
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary

The `ttf-mscorefonts-installer` postinst downloads each font from SourceForge and can fail transiently without failing the apt step — seen in [HEAD-of-deps run 29801635509](https://github.com/scikit-hep/mplhep/actions/runs/29801635509) (2026-07-21), where an HTTP 522 on `impact32.exe` meant no MS fonts were installed at all. The old "List available fonts" step masked this with `|| echo`, so the breakage only surfaced later as confusing `Image dimensions did not match` failures in `test_style_lhcb`/`test_style_lhcb2` (the only tests using Times New Roman).

`ci.yml` already guards against this with a hard `fc-list` check; this PR replicates that pattern in the remaining workflows:

- `head-dependencies.yml` (all four jobs)
- `ci_latex.yml`
- `ci-pages.yml`

The install step now runs with `set -euo pipefail`, refreshes the font cache, and exits 1 with an explicit error if Times New Roman is absent — so a font-download flake fails fast at the install step instead of masquerading as a rendering regression.

## Test plan

- [x] All four workflow files parse as valid YAML
- [x] No masked `|| echo` font listings remain in any workflow
- [ ] CI on this PR exercises the new step directly (ci.yml path unchanged, already proven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb2vYvYgC8rW2hCTzeK3ru