### PR TITLE
chore: require matplotlib>=3.11 in pixi env; pin mkdocs-matplotlib in docs builds

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install package and documentation dependencies
         run: |
           uv pip install -e ".[all]"
-          uv pip install git+https://github.com/andrzejnovak/mkdocs-matplotlib.git
+          uv pip install git+https://github.com/andrzejnovak/mkdocs-matplotlib.git@e3d9ce14a6f0a1fea9550323439b7db93f220b38
           uv pip list
 
       - name: Delete mike version

--- a/new_docs/requirements.txt
+++ b/new_docs/requirements.txt
@@ -2,4 +2,4 @@ docstring-inheritance
 griffe-inherited-docstrings
 markdown-exec
 mike
-mkdocs-matplotlib @ git+https://github.com/andrzejnovak/mkdocs-matplotlib.git
+mkdocs-matplotlib @ git+https://github.com/andrzejnovak/mkdocs-matplotlib.git@e3d9ce14a6f0a1fea9550323439b7db93f220b38

--- a/pixi.toml
+++ b/pixi.toml
@@ -51,7 +51,9 @@ ghostscript = "*"
 [pypi-dependencies]
 # Install matplotlib and dependents via pip to get freetype 2.6.1 (embedded in PyPI wheels)
 # This ensures pytest-mpl baseline images match CI (which uses uv/pip)
-matplotlib = ">=3.10.8"
+# Must be >=3.11.0: label.py's _descent_from_layout relies on the mpl>=3.11
+# Text._get_layout return format (matches the pin in pyproject.toml).
+matplotlib = ">=3.11.0"
 pytest-mpl = "*"
 hist = "*"
 seaborn = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -51,9 +51,10 @@ ghostscript = "*"
 [pypi-dependencies]
 # Install matplotlib and dependents via pip to get freetype 2.6.1 (embedded in PyPI wheels)
 # This ensures pytest-mpl baseline images match CI (which uses uv/pip)
-# Must be >=3.11.0: label.py's _descent_from_layout relies on the mpl>=3.11
-# Text._get_layout return format (matches the pin in pyproject.toml).
-matplotlib = ">=3.11.0"
+# Must match the pyproject.toml floor (>=3.11.1): label.py's
+# _descent_from_layout relies on the mpl>=3.11 Text._get_layout return
+# format, and postinstall's `pip install --no-deps` skips dependency checks.
+matplotlib = ">=3.11.1"
 pytest-mpl = "*"
 hist = "*"
 seaborn = "*"
@@ -91,7 +92,7 @@ markdown-exec = "*"
 docstring-inheritance = "*"
 griffe-inherited-docstrings = "*"
 neoteroi-mkdocs = "*"
-mkdocs-matplotlib = { git = "https://github.com/andrzejnovak/mkdocs-matplotlib.git" }
+mkdocs-matplotlib = { git = "https://github.com/andrzejnovak/mkdocs-matplotlib.git", rev = "e3d9ce14a6f0a1fea9550323439b7db93f220b38" }
 
 [feature.docs.tasks]
 docs-postinstall = "pip install --no-deps -e ."


### PR DESCRIPTION
## Summary

- **pixi: require `matplotlib>=3.11.1`** — `label.py`'s `_descent_from_layout` relies on the mpl≥3.11 `Text._get_layout` return format; a 3.10.x env crashes on any label render, which made the local docs env unable to build the docs. The floor matches `pyproject.toml` exactly (`matplotlib>=3.11.1`) because the `docs-postinstall` task uses `pip install --no-deps -e .`, so pip never enforces the project's own floor inside the pixi env.
- **Pin `mkdocs-matplotlib` to `e3d9ce1`** in `ci-pages.yml`, `new_docs/requirements.txt`, and `pixi.toml` (`[feature.docs.pypi-dependencies]`) — docs builds previously installed the plugin from unpinned git master, so any push to the fork silently changed doc output. Pinning all three keeps CI deploys and local `pixi run docs-build` reproducible and in agreement. `e3d9ce1` is the rev that writes content-hashed image files instead of base64-inlining figures into the pages (the fix that shrank guide pages from ~34MB to ~1.1MB and stopped gh-pages growing ~80MB per deploy).

Future plugin updates should bump the pin in all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
