### PR TITLE
chore(docs): document lean clones; harden retro-deploy of old tags

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -11,6 +11,15 @@ on:
         description: 'Delete a mike version (e.g. pr-683). Leave empty to skip.'
         required: false
         type: string
+      make_latest:
+        description: 'Point the "latest" alias and the site default at deploy_version. Leave off when re-deploying an OLD tag.'
+        required: false
+        default: false
+        type: boolean
+      matplotlib_pin:
+        description: 'Optional matplotlib constraint for the deploy_version build (e.g. "matplotlib>=3.10.8,<3.11"). Old tags predate the mpl>=3.11 Text._get_layout change and crash without this.'
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -74,25 +83,46 @@ jobs:
 
       - name: Delete mike version
         if: inputs.delete_version != ''
+        env:
+          DELETE_VERSION: ${{ inputs.delete_version }}
         run: |
           cd new_docs
-          mike delete --push ${{ inputs.delete_version }}
+          mike delete --push "$DELETE_VERSION"
 
       - name: Deploy docs for specific tag
         if: inputs.deploy_version != ''
+        env:
+          DEPLOY_VERSION: ${{ inputs.deploy_version }}
+          MAKE_LATEST: ${{ inputs.make_latest }}
+          MATPLOTLIB_PIN: ${{ inputs.matplotlib_pin }}
         run: |
+          set -euo pipefail
           # Save current docs config (has mike version provider etc.)
           cp -r new_docs /tmp/new_docs_config
           # Checkout old tag for source code only
-          git checkout ${{ inputs.deploy_version }} -- src/
+          git checkout "$DEPLOY_VERSION" -- src/
           uv pip install --reinstall --no-deps -e ".[all]"
+          # Old tags may need an older matplotlib than the current floor: pre-1.1
+          # label.py unpacks Text._get_layout()[2] as a scalar descent, but mpl>=3.11
+          # returns a tuple there, so every label render raises TypeError.
+          if [ -n "$MATPLOTLIB_PIN" ]; then
+            uv pip install --reinstall "$MATPLOTLIB_PIN"
+          fi
+          python -c "import matplotlib, mplhep; print('matplotlib', matplotlib.__version__, '/ mplhep', mplhep.__version__)"
           # Restore current docs config
           rm -rf new_docs
           cp -r /tmp/new_docs_config new_docs
           cd new_docs
-          VERSION=$(echo "${{ inputs.deploy_version }}" | sed 's/^v//' | cut -d. -f1,2)
-          mike deploy --push --update-aliases "$VERSION" latest
-          mike set-default --push latest
+          VERSION=$(echo "$DEPLOY_VERSION" | sed 's/^v//' | cut -d. -f1,2)
+          # Only move the "latest" alias / site default when deploying the newest
+          # release. Re-deploying an old tag must not repoint latest at it.
+          if [ "$MAKE_LATEST" = "true" ]; then
+            mike deploy --push --update-aliases "$VERSION" latest
+            mike set-default --push latest
+          else
+            echo "Deploying $VERSION without touching the 'latest' alias or site default."
+            mike deploy --push "$VERSION"
+          fi
 
       - name: Deploy dev documentation
         if: inputs.deploy_version == '' && inputs.delete_version == '' && github.ref == 'refs/heads/main'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,61 @@ We are happy to accept contributions to `mplhep` via Pull Requests to the GitHub
 
 Please open an [issue](https://github.com/scikit-hep/mplhep/issues).
 
+## Cloning the repository
+
+The `gh-pages` branch holds the built documentation for every released version. It is by far
+the largest thing in the repository — around 50 MB against ~26 MB for all the code branches
+combined — and nothing in the development workflow needs it. Cloning it by default just
+makes every contributor download the published docs site.
+
+### Recommended clone
+
+Clone `main` only, then widen to the other code branches while keeping `gh-pages` excluded:
+
+```bash
+git clone --single-branch --branch main https://github.com/scikit-hep/mplhep.git
+cd mplhep
+git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+git config --add remote.origin.fetch '^refs/heads/gh-pages'
+git fetch
+```
+
+That lands at ~28 MB of `.git` with every code branch visible to `git branch -r`, so
+`git checkout some/feature-branch` and PR review work normally. `gh-pages` is never
+downloaded, and plain `git fetch` will not pull it later.
+
+The `^refs/heads/gh-pages` line is a *negative refspec* and needs git ≥ 2.29. If you only
+ever work on `main`, the first command on its own is enough (~26 MB).
+
+### Getting the built docs when you actually need them
+
+Only inspecting or repairing the published site requires `gh-pages`. An explicit refspec on
+the command line overrides the exclusion, so no config change is needed:
+
+```bash
+git fetch origin gh-pages:refs/remotes/origin/gh-pages
+```
+
+That adds ~43 MB. It is sticky — a later `git fetch --prune` will not remove it. To go back
+to a lean clone, use the recipe below.
+
+A plain `git clone` with no flags also still works and fetches everything (~71 MB of `.git`).
+
+### Slimming an existing clone
+
+If you already have `gh-pages` locally, exclude it and reclaim the space (~69 MB → ~27 MB):
+
+```bash
+git config --add remote.origin.fetch '^refs/heads/gh-pages'
+git update-ref -d refs/remotes/origin/gh-pages
+git reflog expire --expire=now --all
+git gc --prune=now
+```
+
+Deleting the ref explicitly is the part that matters: `git fetch --prune` will *not* remove
+a remote-tracking ref that falls outside the current refspec, and `git gc` cannot reclaim
+the objects while any ref still points at them.
+
 ## Installing the development environment
 
 ```bash


### PR DESCRIPTION
## Summary

Two unrelated docs-infrastructure fixes, both found while re-deploying the 1.0/1.1/1.2 documentation.

### Lean clones (`CONTRIBUTING.md`)

`gh-pages` holds the built docs for every released version — ~50 MB, against ~26 MB for all
code branches combined. A default `git clone` therefore ships the published docs site to
every contributor, and nothing in the development workflow needs it.

Documents a clone that stays lean **without** losing branch visibility, by excluding only
`gh-pages` with a negative refspec rather than narrowing to a single branch:

```bash
git clone --single-branch --branch main https://github.com/scikit-hep/mplhep.git
cd mplhep
git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
git config --add remote.origin.fetch '^refs/heads/gh-pages'
git fetch
```

Measured on a real clone: **28 MB** of `.git` with every code branch visible to
`git branch -r`, so `git checkout some/branch` and PR review work normally. Also documents
fetching `gh-pages` on demand (28 MB → 71 MB) and slimming an existing clone
(69 MB → 27 MB). Every figure and command in the section was verified against actual clones.

One non-obvious gotcha is called out: `git fetch --prune` does **not** remove a
remote-tracking ref that falls outside the current refspec, so it has to be deleted
explicitly before `git gc` can reclaim anything.

### Retro-deploy of old tags (`ci-pages.yml`)

The `deploy_version` path had two problems, both hit when re-deploying v1.0.0's docs:

- It ran `mike deploy --update-aliases "$VERSION" latest` and `mike set-default --push latest`
  unconditionally, so re-deploying an **old** tag repointed the `latest` alias and the site
  default at it. Now gated behind a new `make_latest` input, defaulting to `false`.

- Old tags need an era-correct matplotlib. Building them against the current floor does not
  fail — it silently mis-renders. Pre-1.3 `label.py` assumed the `Text._get_layout` format
  change landed in mpl 3.12 when it actually landed in 3.11, so under a current matplotlib it
  takes the wrong branch and computes a bad descent, displacing experiment labels. This is
  exactly what left the 1.1 and 1.2 docs with overlapping labels. Adds a `matplotlib_pin`
  input, applied after the `--no-deps` reinstall, plus a line echoing the resolved versions.

Dispatch inputs also moved out of `${{ }}` interpolation into `env:`, and `set -euo pipefail`
added.

## Testing

The `matplotlib_pin` approach is what produced the current live 1.0/1.1/1.2 docs. The v1.0.0
rebuild was pixel-compared against the original published build and is visually identical
apart from the plugin's dpi default change.

Not covered here: docs deploys from release tags never actually publish — see #753.
