### PR TITLE
docs: document clone size trade-off; require confirmation to commit and push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,18 @@
 # Agentic development instructions
 
 # Key rules
-- Never make difficult to revert git operations like git push and absolutely never with   `--force`
-- Never make a commit unless explicitly instructed to do so
+- Ask for confirmation before committing. Editing files freely is fine; turning those edits
+  into a commit is the user's call. Amending or rewriting existing commits needs its own
+  confirmation, separate from any approval to commit
+- Ask for confirmation before anything that reaches the remote — `git push`, opening or
+  editing a pull request, creating or deleting remote branches or tags. Doing it on request
+  is fine; doing it unprompted is not. Approval is per-request and does not carry over: being
+  told to push one branch is not permission to push the next one.
+- Never push to `main`/`master` unless explicitly instructed to do so
+- Never force-push unless explicitly instructed. `--force` needs its own confirmation even
+  when a plain push was already approved, and `--force-with-lease` is preferred over `--force`
+- Prefer proposing the command for the user to run over running it, when an operation is hard
+  to undo. Say plainly what is irreversible about it
 
 
 # Development guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,67 @@ We are happy to accept contributions to `mplhep` via Pull Requests to the GitHub
 
 Please open an [issue](https://github.com/scikit-hep/mplhep/issues).
 
+## Cloning the repository
+
+A plain clone works and is all most contributors need:
+
+```bash
+git clone https://github.com/scikit-hep/mplhep.git
+```
+
+That lands at ~71 MB of `.git`, of which ~45 MB is the `gh-pages` branch — the built
+documentation site for every released version. Nothing in the development workflow uses it.
+
+There is no way for the repository to make a default `git clone` skip a branch: the refspec
+is chosen by the client, and git's server-side `uploadpack.hideRefs` is not something GitHub
+exposes. So skipping the built docs has to be opted into, as below.
+
+### Skipping the built docs (optional)
+
+Clone `main` only, then widen to the other code branches while keeping `gh-pages` excluded:
+
+```bash
+git clone --single-branch --branch main https://github.com/scikit-hep/mplhep.git
+cd mplhep
+git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+git config --add remote.origin.fetch '^refs/heads/gh-pages'
+git fetch
+```
+
+That lands at ~28 MB of `.git` with every code branch visible to `git branch -r`, so
+`git checkout some/feature-branch` and PR review work normally. `gh-pages` is never
+downloaded, and plain `git fetch` will not pull it later.
+
+The `^refs/heads/gh-pages` line is a *negative refspec* and needs git ≥ 2.29. If you only
+ever work on `main`, the first command on its own is enough (~26 MB).
+
+### Getting the built docs when you actually need them
+
+Only inspecting or repairing the published site requires `gh-pages`. An explicit refspec on
+the command line overrides the exclusion, so no config change is needed:
+
+```bash
+git fetch origin gh-pages:refs/remotes/origin/gh-pages
+```
+
+That adds ~43 MB. It is sticky — a later `git fetch --prune` will not remove it. To go back
+to a lean clone, use the recipe below.
+
+### Slimming an existing clone
+
+If you already have `gh-pages` locally, exclude it and reclaim the space (~69 MB → ~27 MB):
+
+```bash
+git config --add remote.origin.fetch '^refs/heads/gh-pages'
+git update-ref -d refs/remotes/origin/gh-pages
+git reflog expire --expire=now --all
+git gc --prune=now
+```
+
+Deleting the ref explicitly is the part that matters: `git fetch --prune` will *not* remove
+a remote-tracking ref that falls outside the current refspec, and `git gc` cannot reclaim
+the objects while any ref still points at them.
+
 ## Installing the development environment
 
 ```bash


### PR DESCRIPTION
## Summary

Two docs-only changes. No workflow or source changes — the `ci-pages.yml` retro-deploy
hardening that was in #754 is deliberately left out, since it belongs with the fix for #753.

### `CONTRIBUTING.md` — clone size

The `gh-pages` branch holds the built documentation site for every released version. It is
~45 MB of a ~71 MB clone, and nothing in the development workflow uses it.

A repository **cannot** make a default `git clone` skip a branch: the refspec is chosen by
the client, and git's server-side `uploadpack.hideRefs` is not something GitHub exposes. So
this documents the plain clone as the normal path, and adds an opt-in recipe for anyone who
wants to avoid the docs payload:

```bash
git clone --single-branch --branch main https://github.com/scikit-hep/mplhep.git
cd mplhep
git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
git config --add remote.origin.fetch '^refs/heads/gh-pages'
git fetch
```

~28 MB of `.git`, with every code branch still visible to `git branch -r`, so
`git checkout some/branch` and PR review work normally. Excluding only `gh-pages` with a
negative refspec is deliberately preferred over `git remote set-branches origin main`, which
would also cost branch visibility.

Also documents fetching `gh-pages` on demand and slimming an existing clone. Every size and
command was verified against real clones. One non-obvious point is called out explicitly:
`git fetch --prune` does **not** remove a remote-tracking ref that falls outside the current
refspec, so it has to be deleted by hand before `git gc` can reclaim the space.

### `AGENTS.md` — agent git policy

The existing rules were blanket bans ("never commit", "never push"), which do not match how
the work actually happens — both get requested routinely. Relaxed into
confirmation-required rules, while keeping hard limits where a mistake is expensive:

- ask before committing; amending or rewriting history needs its own confirmation
- ask before anything that reaches the remote (push, PRs, remote branches/tags), and
  approval is per-request rather than standing
- never push to `main`/`master` without explicit instruction
- never force-push without explicit instruction; prefer `--force-with-lease`
- prefer proposing hard-to-undo commands over running them, and say what is irreversible

## Note

Worth considering separately: matplotlib has no `gh-pages` branch at all — its built docs
live in `matplotlib/matplotlib.github.com` (~6.9 GB). Moving mplhep's `gh-pages` to a
separate repo is the only way to make a *default* clone lean, and it is the standard pattern
in this ecosystem. Not attempted here.
