### PR TITLE
ci(docs)!: publish the built site to scikit-hep/mplhep_docs

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -11,6 +11,15 @@ on:
         description: 'Delete a mike version (e.g. pr-683). Leave empty to skip.'
         required: false
         type: string
+      make_latest:
+        description: 'Point the "latest" alias and the site default at deploy_version. Leave off when re-deploying an OLD tag.'
+        required: false
+        default: false
+        type: boolean
+      matplotlib_pin:
+        description: 'Optional matplotlib constraint for the deploy_version build (e.g. "matplotlib>=3.10.8,<3.11"). Old tags predate the mpl>=3.11 Text._get_layout change and crash without this.'
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -45,6 +54,36 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
+      # The built site lives in scikit-hep/mplhep_docs, not in this repository, so that a
+      # clone of mplhep does not carry the published docs for every release. GITHUB_TOKEN is
+      # scoped to this repo and cannot push there, hence a deploy key scoped to mplhep_docs.
+      # The github-docs Host alias keeps this key off origin, which stays on HTTPS.
+      - name: Configure docs repository access
+        env:
+          DOCS_DEPLOY_KEY: ${{ secrets.DOCS_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DOCS_DEPLOY_KEY:-}" ]; then
+            echo "ERROR: DOCS_DEPLOY_KEY secret is not set; cannot reach scikit-hep/mplhep_docs." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DOCS_DEPLOY_KEY" > ~/.ssh/docs_deploy
+          chmod 600 ~/.ssh/docs_deploy
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat >> ~/.ssh/config <<'EOF'
+          Host github-docs
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/docs_deploy
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+          git remote add docs git@github-docs:scikit-hep/mplhep_docs.git
+          git fetch docs +refs/heads/gh-pages:refs/remotes/docs/gh-pages
+          git branch -f gh-pages docs/gh-pages
+          echo "Tracking $(git rev-parse --short gh-pages) from scikit-hep/mplhep_docs."
+
       - name: Setup uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -74,32 +113,53 @@ jobs:
 
       - name: Delete mike version
         if: inputs.delete_version != ''
+        env:
+          DELETE_VERSION: ${{ inputs.delete_version }}
         run: |
           cd new_docs
-          mike delete --push ${{ inputs.delete_version }}
+          mike delete --push -r docs "$DELETE_VERSION"
 
       - name: Deploy docs for specific tag
         if: inputs.deploy_version != ''
+        env:
+          DEPLOY_VERSION: ${{ inputs.deploy_version }}
+          MAKE_LATEST: ${{ inputs.make_latest }}
+          MATPLOTLIB_PIN: ${{ inputs.matplotlib_pin }}
         run: |
+          set -euo pipefail
           # Save current docs config (has mike version provider etc.)
           cp -r new_docs /tmp/new_docs_config
           # Checkout old tag for source code only
-          git checkout ${{ inputs.deploy_version }} -- src/
+          git checkout "$DEPLOY_VERSION" -- src/
           uv pip install --reinstall --no-deps -e ".[all]"
+          # Old tags may need an older matplotlib than the current floor: pre-1.1
+          # label.py unpacks Text._get_layout()[2] as a scalar descent, but mpl>=3.11
+          # returns a tuple there, so every label render raises TypeError.
+          if [ -n "$MATPLOTLIB_PIN" ]; then
+            uv pip install --reinstall "$MATPLOTLIB_PIN"
+          fi
+          python -c "import matplotlib, mplhep; print('matplotlib', matplotlib.__version__, '/ mplhep', mplhep.__version__)"
           # Restore current docs config
           rm -rf new_docs
           cp -r /tmp/new_docs_config new_docs
           cd new_docs
-          VERSION=$(echo "${{ inputs.deploy_version }}" | sed 's/^v//' | cut -d. -f1,2)
-          mike deploy --push --update-aliases "$VERSION" latest
-          mike set-default --push latest
+          VERSION=$(echo "$DEPLOY_VERSION" | sed 's/^v//' | cut -d. -f1,2)
+          # Only move the "latest" alias / site default when deploying the newest
+          # release. Re-deploying an old tag must not repoint latest at it.
+          if [ "$MAKE_LATEST" = "true" ]; then
+            mike deploy --push -r docs --update-aliases "$VERSION" latest
+            mike set-default --push -r docs latest
+          else
+            echo "Deploying $VERSION without touching the 'latest' alias or site default."
+            mike deploy --push -r docs "$VERSION"
+          fi
 
       - name: Deploy dev documentation
         if: inputs.deploy_version == '' && inputs.delete_version == '' && github.ref == 'refs/heads/main'
         run: |
           cd new_docs
-          mike deploy --push dev
-          mike set-default --push dev
+          mike deploy --push -r docs dev
+          mike set-default --push -r docs dev
 
       - name: Deploy versioned documentation
         if: inputs.deploy_version == '' && inputs.delete_version == '' && startsWith(github.ref, 'refs/tags/v')
@@ -107,8 +167,8 @@ jobs:
           cd new_docs
           # Extract version from tag (v1.2.3 -> 1.2)
           VERSION=$(echo "${GITHUB_REF#refs/tags/v}" | cut -d. -f1,2)
-          mike deploy --push --update-aliases "$VERSION" latest
-          mike set-default --push latest
+          mike deploy --push -r docs --update-aliases "$VERSION" latest
+          mike set-default --push -r docs latest
 
       - name: Export gh-pages for upload
         run: |


### PR DESCRIPTION
## Summary

Moves the built documentation site out of this repository and into
**[scikit-hep/mplhep_docs](https://github.com/scikit-hep/mplhep_docs)**.

`gh-pages` holds the rendered HTML for every released version. It is ~45 MB of a ~71 MB
clone and grows with every release — and we are only four versions in. Every contributor was
downloading the published docs site just to work on the library. After this, a default clone
of mplhep is ~26 MB. Same pattern matplotlib uses with `matplotlib/matplotlib.github.com`
(~6.9 GB, and no `gh-pages` in the main repo at all).

**The public URL does not change.** Pages on this repo is `build_type: workflow`, so it
serves the uploaded artifact rather than a branch; where the branch physically lives is
invisible to visitors.

## How it works

`GITHUB_TOKEN` is scoped to this repository and cannot push to a second one, so the workflow
uses a **deploy key** scoped to `mplhep_docs`. It is write-limited to that one repository,
belongs to no user account, and does not expire — unlike a fine-grained PAT, which caps at a
year and would eventually break docs deploys silently. A `github-docs` SSH `Host` alias keeps
the key off `origin`, which stays on HTTPS with the default token.

Verified before wiring it up:

```
authenticates as     : scikit-hep/mplhep_docs
write to mplhep      : DENIED
write to mplhep_docs : OK
```

Every `mike` write now targets `-r docs`, and the export step reads the `gh-pages` branch
fetched from there.

## Also carries the retro-deploy fixes from the closed #754

- `make_latest` gates the `latest` alias and site default, so re-deploying an **old** tag no
  longer repoints them at it
- `matplotlib_pin` allows an era-correct matplotlib for old tags. Building them against the
  current floor does not fail, it silently mis-renders: pre-1.3 `label.py` assumed the
  `Text._get_layout` change landed in mpl 3.12 when it landed in 3.11, misplacing experiment
  labels. This is what left the 1.1 and 1.2 docs with overlapping labels
- dispatch inputs moved out of `${{ }}` interpolation into `env:`, plus `set -euo pipefail`

## Testing

Run 30013507178 on this branch: build job green, including `Configure docs repository access`
(deploy key works in CI, `* [new branch] gh-pages -> docs/gh-pages`) and
`Export gh-pages for upload`. Artifact 149 MB, matching the 152 MB produced before the split.
All `mike` steps correctly skipped on a non-`main` ref. The `deploy` job failed on the
environment branch policy, which is expected for any non-`main` ref — see #753.

## Merge checklist

1. `DOCS_DEPLOY_KEY` secret is already set on this repo, and the deploy key is already on
   `mplhep_docs` with write access
2. `mplhep_docs` already holds the current site (all five versions), pushed from the existing
   `gh-pages`
3. Merging triggers a `main` run, which does `mike deploy -r docs dev` and publishes —
   that is the first end-to-end exercise of the write path
4. **After** verifying the live site, `gh-pages` in this repository can be deleted. Until
   then it is untouched, so this is fully reversible

Closes nothing on its own; #753 (tag deploys never publish) is unaffected and still open.
