### PR TITLE
fix(ci): publish docs via workflow_run so tag deploys reach the site

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -20,6 +20,11 @@ on:
         description: 'Optional matplotlib constraint for the deploy_version build (e.g. "matplotlib>=3.10.8,<3.11"). Old tags predate the mpl>=3.11 Text._get_layout change and crash without this.'
         required: false
         type: string
+      publish_only:
+        description: 'Skip every mike step and only publish the current mplhep_docs gh-pages branch. Used to republish after a tag deploy, which cannot publish on its own.'
+        required: false
+        default: false
+        type: boolean
   push:
     branches:
       - main
@@ -31,6 +36,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  actions: write # to dispatch the follow-up publish run after a tag deploy
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -43,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -93,6 +100,7 @@ jobs:
           enable-cache: true
 
       - name: Install core fonts
+        if: '!inputs.publish_only'
         run: |
           set -euo pipefail
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
@@ -106,13 +114,14 @@ jobs:
           echo "Times New Roman font verified successfully."
 
       - name: Install package and documentation dependencies
+        if: '!inputs.publish_only'
         run: |
           uv pip install -e ".[all]"
           uv pip install git+https://github.com/andrzejnovak/mkdocs-matplotlib.git@e3d9ce14a6f0a1fea9550323439b7db93f220b38
           uv pip list
 
       - name: Delete mike version
-        if: inputs.delete_version != ''
+        if: inputs.delete_version != '' && !inputs.publish_only
         env:
           DELETE_VERSION: ${{ inputs.delete_version }}
         run: |
@@ -120,7 +129,7 @@ jobs:
           mike delete --push -r docs "$DELETE_VERSION"
 
       - name: Deploy docs for specific tag
-        if: inputs.deploy_version != ''
+        if: inputs.deploy_version != '' && !inputs.publish_only
         env:
           DEPLOY_VERSION: ${{ inputs.deploy_version }}
           MAKE_LATEST: ${{ inputs.make_latest }}
@@ -155,20 +164,35 @@ jobs:
           fi
 
       - name: Deploy dev documentation
-        if: inputs.deploy_version == '' && inputs.delete_version == '' && github.ref == 'refs/heads/main'
+        if: inputs.deploy_version == '' && inputs.delete_version == '' && !inputs.publish_only && github.ref == 'refs/heads/main'
         run: |
           cd new_docs
           mike deploy --push -r docs dev
-          mike set-default --push -r docs dev
+          # Deliberately no `mike set-default` here. The site default belongs to
+          # `latest`; setting it to dev on every merge to main is what left the root
+          # redirecting to dev/ between releases.
 
       - name: Deploy versioned documentation
-        if: inputs.deploy_version == '' && inputs.delete_version == '' && startsWith(github.ref, 'refs/tags/v')
+        if: inputs.deploy_version == '' && inputs.delete_version == '' && !inputs.publish_only && startsWith(github.ref, 'refs/tags/v')
         run: |
           cd new_docs
           # Extract version from tag (v1.2.3 -> 1.2)
           VERSION=$(echo "${GITHUB_REF#refs/tags/v}" | cut -d. -f1,2)
           mike deploy --push -r docs --update-aliases "$VERSION" latest
           mike set-default --push -r docs latest
+
+      # A deployment created from a tag ref is recorded as successful but never actually
+      # serves; only deployments from `main` reach the site. The commits mike just pushed
+      # to mplhep_docs would therefore stay invisible. Re-run this workflow on main in
+      # publish-only mode, which exports the now-updated branch and publishes it for real.
+      - name: Republish from main
+        if: inputs.deploy_version == '' && inputs.delete_version == '' && !inputs.publish_only && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Tag deploys cannot publish; dispatching a publish-only run on main."
+          gh workflow run ci-pages.yml --ref main -f publish_only=true
 
       - name: Export gh-pages for upload
         run: |

--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -20,11 +20,6 @@ on:
         description: 'Optional matplotlib constraint for the deploy_version build (e.g. "matplotlib>=3.10.8,<3.11"). Old tags predate the mpl>=3.11 Text._get_layout change and crash without this.'
         required: false
         type: string
-      publish_only:
-        description: 'Skip every mike step and only publish the current mplhep_docs gh-pages branch. Used to republish after a tag deploy, which cannot publish on its own.'
-        required: false
-        default: false
-        type: boolean
   push:
     branches:
       - main
@@ -32,16 +27,15 @@ on:
       - 'v*'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Publishing happens in pages-publish.yml; this workflow only writes to mplhep_docs.
 permissions:
   contents: write
-  pages: write
-  id-token: write
-  actions: write # to dispatch the follow-up publish run after a tag deploy
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Serialise doc builds so concurrent mike runs cannot race each other pushing to
+# mplhep_docs. Deliberately a different group from pages-publish.yml, which would
+# otherwise wait on a run that has to finish before it can even start.
 concurrency:
-  group: "pages"
+  group: "docs-build"
   cancel-in-progress: false
 
 jobs:
@@ -49,7 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -100,7 +93,6 @@ jobs:
           enable-cache: true
 
       - name: Install core fonts
-        if: '!inputs.publish_only'
         run: |
           set -euo pipefail
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
@@ -114,14 +106,13 @@ jobs:
           echo "Times New Roman font verified successfully."
 
       - name: Install package and documentation dependencies
-        if: '!inputs.publish_only'
         run: |
           uv pip install -e ".[all]"
           uv pip install git+https://github.com/andrzejnovak/mkdocs-matplotlib.git@e3d9ce14a6f0a1fea9550323439b7db93f220b38
           uv pip list
 
       - name: Delete mike version
-        if: inputs.delete_version != '' && !inputs.publish_only
+        if: inputs.delete_version != ''
         env:
           DELETE_VERSION: ${{ inputs.delete_version }}
         run: |
@@ -129,7 +120,7 @@ jobs:
           mike delete --push -r docs "$DELETE_VERSION"
 
       - name: Deploy docs for specific tag
-        if: inputs.deploy_version != '' && !inputs.publish_only
+        if: inputs.deploy_version != ''
         env:
           DEPLOY_VERSION: ${{ inputs.deploy_version }}
           MAKE_LATEST: ${{ inputs.make_latest }}
@@ -164,7 +155,7 @@ jobs:
           fi
 
       - name: Deploy dev documentation
-        if: inputs.deploy_version == '' && inputs.delete_version == '' && !inputs.publish_only && github.ref == 'refs/heads/main'
+        if: inputs.deploy_version == '' && inputs.delete_version == '' && github.ref == 'refs/heads/main'
         run: |
           cd new_docs
           mike deploy --push -r docs dev
@@ -173,47 +164,10 @@ jobs:
           # redirecting to dev/ between releases.
 
       - name: Deploy versioned documentation
-        if: inputs.deploy_version == '' && inputs.delete_version == '' && !inputs.publish_only && startsWith(github.ref, 'refs/tags/v')
+        if: inputs.deploy_version == '' && inputs.delete_version == '' && startsWith(github.ref, 'refs/tags/v')
         run: |
           cd new_docs
           # Extract version from tag (v1.2.3 -> 1.2)
           VERSION=$(echo "${GITHUB_REF#refs/tags/v}" | cut -d. -f1,2)
           mike deploy --push -r docs --update-aliases "$VERSION" latest
           mike set-default --push -r docs latest
-
-      # A deployment created from a tag ref is recorded as successful but never actually
-      # serves; only deployments from `main` reach the site. The commits mike just pushed
-      # to mplhep_docs would therefore stay invisible. Re-run this workflow on main in
-      # publish-only mode, which exports the now-updated branch and publishes it for real.
-      - name: Republish from main
-        if: inputs.deploy_version == '' && inputs.delete_version == '' && !inputs.publish_only && startsWith(github.ref, 'refs/tags/v')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          echo "Tag deploys cannot publish; dispatching a publish-only run on main."
-          gh workflow run ci-pages.yml --ref main -f publish_only=true
-
-      - name: Export gh-pages for upload
-        run: |
-          git worktree add _gh-pages gh-pages
-          rm -rf _gh-pages/.git
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: _gh-pages
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages-publish.yml
+++ b/.github/workflows/pages-publish.yml
@@ -1,0 +1,62 @@
+name: Publish Documentation
+
+# Publishing is split out from ci-pages.yml because a GitHub Pages deployment only
+# actually serves when its run is on the default branch. A run started by a tag push
+# records a successful deployment that never reaches the site, which meant versioned
+# docs for a release were built, pushed, and then silently not published.
+#
+# A workflow_run-triggered workflow always executes on the default branch, whatever
+# started the upstream run. Routing every publish through here means tags and merges
+# publish by the same path, and no part of the workflow needs to know which refs can
+# serve.
+on:
+  workflow_run:
+    workflows: ["Deploy Documentation"]
+    types: [completed]
+  # Manual republish, e.g. after editing scikit-hep/mplhep_docs directly.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # Never publish on top of a failed build: mplhep_docs may be half-updated.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # mplhep_docs is public, so this is an anonymous read. The deploy key lives in
+      # ci-pages.yml, which is the only workflow that needs to *write* there.
+      - name: Fetch the built site from mplhep_docs
+        run: |
+          set -euo pipefail
+          git clone --quiet --depth 1 --branch gh-pages \
+            https://github.com/scikit-hep/mplhep_docs.git _gh-pages
+          echo "Publishing $(git -C _gh-pages rev-parse --short HEAD) from mplhep_docs."
+          rm -rf _gh-pages/.git
+          echo "$(find _gh-pages -type f | wc -l) files, $(du -sh _gh-pages | cut -f1)."
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _gh-pages
+
+  deploy:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Fixes #753.

## 1. Tag deploys never publish

A deployment created from a tag ref is recorded as `success` — it even marks the previous
deployment `inactive` — but it never reaches the site. Only deployments from the default
branch serve.

Observed across five deployments on 2026-07-23:

| Deployment | Ref | Served? |
| --- | --- | --- |
| 07:25 | `main` | yes |
| 07:30 | `v1.3.2` | **no** |
| 10:19 | `tmp-publish-pages` | **no** |
| 10:37 | `tmp-publish-pages` | **no** |
| 11:23 | `main` | yes |

The decisive check is the site root. The tag path ends with `mike set-default latest`, so if
that deployment were serving, the root would redirect to `latest/`. It did not:

```
live root redirect      ->  url=dev/     # what the preceding main run wrote
published gh-pages root ->  url=latest/  # what the tag run committed
```

Caching and a bad artifact were both ruled out: `cf-cache-status: DYNAMIC`, cache-busted and
`no-cache` requests returned identical stale bytes for 11+ minutes, and the uploaded artifact
was verified to contain the correct content.

**Effect:** versioned docs for a release are built, committed and pushed, then silently not
published. The site keeps serving whatever the last merge to `main` produced.

**Fix:** publishing moves into its own workflow, `pages-publish.yml`, triggered by
`workflow_run`. A `workflow_run`-triggered workflow always executes on the default branch,
whatever started the upstream run — so every publish is inherently a `main`-ref run.

Tags and merges now publish by exactly the same path. No part of the workflow encodes which
refs are able to serve, which makes the failure structurally impossible rather than
worked around. `ci-pages.yml` becomes responsible only for building docs and pushing them to
`mplhep_docs`, and drops its `pages`/`id-token` permissions.

`pages-publish.yml` reads `mplhep_docs` anonymously over HTTPS, since that repository is
public — verified: a shallow anonymous clone yields 3031 files across all five versions. The
deploy key stays in `ci-pages.yml`, the only workflow that writes there.

## 2. `dev` steals the site default

The `main` path ended with `mike set-default --push dev`, moving the site default to `dev` on
every merge. Only the tag path set it back to `latest` — and that path never took effect. So
the root has been permanently redirecting to `dev/`; `latest/` is reachable but never the
default. It still is:

```
$ curl -s https://scikit-hep.org/mplhep/ | grep -o 'url=[^"]*'
url=dev/
```

Dropping that one line leaves the default owned by `latest`, set by the release path.

## Notes

`workflow_run` only fires once the workflow file is on the default branch, so this cannot be
exercised on a branch — the first real test is the merge itself, and then the next release
for the tag path. If `Publish Documentation` does not appear after a merge to `main`, the
site simply keeps serving its current artifact, which is the status quo rather than something
worse.

The two workflows deliberately use different concurrency groups: sharing `pages` would have
had the publisher queue behind the very run it is waiting on.

This remains a workaround for an inferred cause. Pages is configured
`build_type: workflow` with `source: {branch: main}` — a `PUT` setting `build_type=workflow`
is accepted but leaves `source` on `main`, so there is no setting that lets a tag-ref
deployment serve. If the real cause turns out to be something else, this can be reverted.