### PR TITLE
docs: fix two broken links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,4 +104,6 @@ nox -s lint
 
 ## Contributing to the documentation
 
-The documentation is built using [MkDocs](https://www.mkdocs.org/) and the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. To contribute to the documentation, please look at the [`new_docs/CONTRIBUTING_DOC.md`](CONTRIBUTING_DOC.md) file for instructions.
+The documentation is built using [MkDocs](https://www.mkdocs.org/) and the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. To contribute to the documentation, please look at the
+[`new_docs/CONTRIBUTING_DOC.md`](https://github.com/scikit-hep/mplhep/blob/main/new_docs/CONTRIBUTING_DOC.md)
+file for instructions.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ https://github.com/firamath/firamath
 
 ### Citation
 
-If you've found this library helpful and are able to, please consider citing it. You can find us on [Zenodo](doi.org/10.5281/zenodo.3766157) as a permalink to the latest version.
+If you've found this library helpful and are able to, please consider citing it. You can find us on [Zenodo](https://doi.org/10.5281/zenodo.3766157) as a permalink to the latest version.
 
 BiBTeX:
 ```


### PR DESCRIPTION
Two genuinely broken links, found while looking for a real change to exercise the docs
deploy with.

## README — Zenodo citation

```markdown
[Zenodo](doi.org/10.5281/zenodo.3766157)
```

No scheme, so Markdown treats it as repository-relative:

```
github.com/scikit-hep/mplhep/blob/main/doi.org/10.5281/zenodo.3766157  ->  404
https://doi.org/10.5281/zenodo.3766157                                 ->  200
```

The citation link in the README has therefore been dead. The DOI itself is fine.

## CONTRIBUTING — link to the docs contributing guide

```markdown
[`new_docs/CONTRIBUTING_DOC.md`](CONTRIBUTING_DOC.md)
```

The file exists only under `new_docs/`, so:

```
GitHub  /blob/main/CONTRIBUTING_DOC.md  ->  404
Docs    /dev/CONTRIBUTING_DOC/          ->  200
```

It worked on the rendered docs site, where the page is a sibling, and 404'd on GitHub —
which is where contributors actually read CONTRIBUTING. No relative path can be right in
both: `new_docs/CONTRIBUTING_DOC.md` would fix GitHub and break the docs site, which has no
`new_docs/` path segment. Replaced with an absolute URL, which is unambiguous either way.

## Also exercises the docs deploy

`CONTRIBUTING.md` is symlinked into `new_docs/docs/` and is in the nav, so merging this runs
the full chain again: source → `mike deploy -r docs` → `mplhep_docs` → `workflow_run` →
publish. The change should appear at
[/dev/CONTRIBUTING/](https://scikit-hep.org/mplhep/dev/CONTRIBUTING/).

The README is not part of the docs site (`index.md` is a separate file), so that half is
GitHub-only.

A sweep of the remaining relative links in README, CONTRIBUTING and AGENTS found nothing
else dangling or scheme-less.
