### PR TITLE
docs: make snippet base_path absolute so RTD renders example code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@
   when a plain push was already approved, and `--force-with-lease` is preferred over `--force`
 - Prefer proposing the command for the user to run over running it, when an operation is hard
   to undo. Say plainly what is irreversible about it
+- Ask for these confirmations as a y/N prompt, not as an open-ended question. Use the
+  question tool with plain `Yes` / `No` options so the answer is one keypress, and put the
+  detail that matters — the exact command, the branch, the target — in the option
+  descriptions rather than in a paragraph the user has to reply to in prose
 
 
 # Development guidelines

--- a/new_docs/docs_hooks.py
+++ b/new_docs/docs_hooks.py
@@ -9,6 +9,35 @@ import sys
 from pathlib import Path
 
 
+def on_config(config):
+    """Run after the configuration is loaded, before the build starts.
+
+    Pins ``pymdownx.snippets``' ``base_path`` to the repository root. The value
+    configured in ``mkdocs.yml`` is resolved against the *current working
+    directory*, not against the config file, so ``../`` only means "repo root"
+    when the build is launched from ``new_docs/`` (as ``noxfile.py`` and the
+    docs workflow do). Read the Docs builds from the checkout root with
+    ``--config-file new_docs/mkdocs.yml``, where ``../`` escapes the repository
+    and every ``--8<--`` snippet silently resolves to nothing, leaving the
+    gallery code blocks empty. Rewriting it to an absolute path makes snippet
+    resolution independent of where mkdocs is invoked from.
+
+    Parameters
+    ----------
+    config : MkDocsConfig
+        The MkDocs configuration object.
+
+    Returns
+    -------
+    MkDocsConfig
+        The configuration with an absolute snippets ``base_path``.
+    """
+    repo_root = Path(__file__).parent.parent.resolve()
+    snippets = config["mdx_configs"].setdefault("pymdownx.snippets", {})
+    snippets["base_path"] = [str(repo_root)]
+    return config
+
+
 def on_pre_build(config):  # noqa: ARG001
     """Run before the build process starts.
 

--- a/new_docs/mkdocs.yml
+++ b/new_docs/mkdocs.yml
@@ -99,8 +99,14 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.snippets:
+      # base_path is resolved against the working directory mkdocs was launched
+      # from, not against this file, so `../` is only correct for builds started
+      # in new_docs/. on_config in docs_hooks.py overrides it with the absolute
+      # repo root so Read the Docs (which builds from the checkout root) finds
+      # the example snippets too. Keep check_paths on: a missing snippet must
+      # fail the build rather than silently render an empty code block.
       base_path: ../
-      check_paths: false
+      check_paths: true
   - pymdownx.inlinehilite
   - pymdownx.superfences
   - pymdownx.details


### PR DESCRIPTION
On Read the Docs, every gallery page renders its Imports / Setup / Code blocks empty. The main docs site is unaffected.

### Cause

`pymdownx.snippets`' `base_path` is resolved against the **working directory mkdocs was launched from**, not against `mkdocs.yml`. `noxfile.py` and `ci-pages.yml` both `cd new_docs` first, so `../` meant the repo root and the `--8<--` example snippets resolved fine. Read the Docs builds from the checkout root with `--config-file new_docs/mkdocs.yml`, where `../` escapes the repository entirely — no snippet file was found, and with `check_paths: false` that failed silently into a blank code block.

### Fix

- `docs_hooks.py`: an `on_config` hook overrides `base_path` with the absolute repo root, so resolution no longer depends on the launch directory.
- `mkdocs.yml`: `check_paths: false` → `true`, so a missing snippet fails the build instead of silently emitting an empty block. That silent-failure mode is why this shipped unnoticed.

### Verification

Built with `mkdocs build -f new_docs/mkdocs_norender.yml` and counted effectively-empty `<code>` blocks across all 19 gallery pages:

| build | empty code blocks |
| --- | --- |
| repo root (RTD-style), before | 72 / 72 |
| repo root (RTD-style), after | 0 / 72 |
| from `new_docs/` (local + CI), after | 0 / 72, exit 0 |

The new guard was also checked in isolation: with the hook reverted but `check_paths: true`, the build aborts with `SnippetMissingError: Snippet at path 'examples/1d_histograms/1d_comparison_asymmetry.py' could not be found` instead of producing blank blocks.

Only the `norender` config was exercised, so `mkdocs_matplotlib` figure rendering is untouched and untested here — snippet handling is identical in the full config, which `INHERIT`s this one.

### Also included

A second commit updates `AGENTS.md` to ask for commit/push confirmations as a one-keypress y/N prompt rather than an open-ended prose question. Unrelated to the docs fix; happy to split it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115CvkR5UJnmTVwT17yKKXY