### PR TITLE
docs: tighten the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,28 @@
-<!-- PR titles follow Conventional Commits: https://www.conventionalcommits.org/ -->
+<!--
+PR titles follow Conventional Commits: https://www.conventionalcommits.org/
+-->
 
 ## Description
+
+## Proposed commit message
+
+<!-- If this PR is squash-merged, this is what lands on main. Skip it if your
+     commits are already well organised and should be merged as a rebase.
+     Keep the Assisted-by trailer if AI was used; delete the line if not. -->
+
+```text
+<type>(<scope>): <summary>
+
+<body>
+
+Assisted-by: <harness>:<model>
+```
 
 ## Checklist
 
 - [ ] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
+- [ ] Tests added or updated for the change if changing code
+- [ ] Only genuinely modified baseline images are included
 
 ## AI assistance
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,43 +1,9 @@
-<!--
-Thanks for contributing to mplhep!
-
-PR titles follow Conventional Commits: https://www.conventionalcommits.org/
--->
+<!-- PR titles follow Conventional Commits: https://www.conventionalcommits.org/ -->
 
 ## Description
 
-<!-- What does this change and why? -->
-
-## Proposed commit message
-
-<!-- If this PR is squash-merged, this is what lands on main. Skip it if your
-     commits are already well organised and should be merged as they are.
-     Keep the Assisted-by trailer if AI was used; delete the line if not. -->
-
-```text
-<type>(<scope>): <summary>
-
-<body>
-
-Assisted-by: <harness>:<model>
-```
-
 ## Checklist
 
-<!-- CI runs the full test suite and pre-commit.ci handles linting, so only the
-     things CI cannot check are listed here. -->
-
+- [ ] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
 - [ ] Tests added or updated for the change
 - [ ] Only genuinely modified baseline images are included
-
-## AI assistance
-
-See the [AI Policy](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md#ai-policy). Pick one:
-
-- [ ] No AI was used, or only for translation/grammar.
-- [ ] AI was used. Tool and model: <!-- e.g. claude-code:claude-opus-5 -->
-
-  By checking this you confirm you have reviewed and understood every line, you
-  will respond to review comments yourself, and the commit message credits the
-  assistance with `Assisted-by: <harness>:<model>` — never `Co-authored-by:` or
-  `Signed-off-by:`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,15 @@
 ## Checklist
 
 - [ ] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
-- [ ] Tests added or updated for the change
-- [ ] Only genuinely modified baseline images are included
+
+## AI assistance
+
+See the [AI Policy](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md#ai-policy). Pick one:
+
+- [ ] No AI was used, or only for translation/grammar.
+- [ ] AI was used. Tool and model: <!-- e.g. claude-code:claude-opus-5 -->
+
+  By checking this you confirm you have reviewed and understood every line, you
+  will respond to review comments yourself, and the commit message credits the
+  assistance with `Assisted-by: <harness>:<model>` — never `Co-authored-by:` or
+  `Signed-off-by:`.


### PR DESCRIPTION
## Description

Follow-up to #761, tightening the PR template that landed there. The net change
against `main`:

- Adds a **"I have read the contributing guidelines"** box. That is the one
  thing worth asking on every PR, and it covers everything in `CONTRIBUTING.md`
  including the AI policy.
- Scopes the tests box to **"if changing code"**, so documentation PRs are not
  ticking a box that does not apply to them.
- The non-squash path now says **"merged as a rebase"** rather than "merged as
  they are", which names what actually happens.
- Drops the greeting and two explanatory comments — the note about what CI
  covers, and the "what does this change and why" prompt under Description.
  Neither is something a contributor needs at fill-in time.

The commit-message block and the AI assistance section are unchanged. No change
to the policy itself.

## Proposed commit message

```text
docs: tighten the PR template

Adds a box confirming the contributing guidelines were read, scopes the
tests box to code changes, and says rebase rather than "merged as they
are" for the non-squash path. Drops the greeting and two explanatory
comments that told contributors things they do not need at fill-in time.

Assisted-by: claude-code:claude-opus-5
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
- [x] Tests added or updated for the change if changing code — n/a, documentation only
- [x] Only genuinely modified baseline images are included — n/a

## AI assistance

- [x] AI was used. Tool and model: `claude-code:claude-opus-5`

Assisted-by: claude-code:claude-opus-5
