### PR TITLE
docs: drop the claim that the PR body is what lands on main

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,10 +14,7 @@ The project's AI policy is in `CONTRIBUTING.md` ("AI Policy") and applies to you
 - Never add `Signed-off-by:` and never use `git commit -s`. It certifies the Developer
   Certificate of Origin, which only a human can do.
 - Never add "Generated with ..." footers, session URLs, or tool links.
-- Put the trailer in your commit messages, which is the only place it needs to be. A
-  squash-merge builds the final message from the branch's commits, so it carries
-  through; the PR description is not used. Prefer a single commit per PR, or the
-  trailer repeats once per commit in the squashed message.
+- Put the trailer in the commit, and in any squash message proposed in the PR body.
 - Disclose the tool and model in the PR description.
 
 ## Folder Structure

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,8 +14,10 @@ The project's AI policy is in `CONTRIBUTING.md` ("AI Policy") and applies to you
 - Never add `Signed-off-by:` and never use `git commit -s`. It certifies the Developer
   Certificate of Origin, which only a human can do.
 - Never add "Generated with ..." footers, session URLs, or tool links.
-- Put the trailer in your commit messages. PRs are often squash-merged, and then the
-  message proposed in the PR body is what lands on `main` — put it there too.
+- Put the trailer in your commit messages, which is the only place it needs to be. A
+  squash-merge builds the final message from the branch's commits, so it carries
+  through; the PR description is not used. Prefer a single commit per PR, or the
+  trailer repeats once per commit in the squashed message.
 - Disclose the tool and model in the PR description.
 
 ## Folder Structure

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,11 @@ PR titles follow Conventional Commits: https://www.conventionalcommits.org/
 
 ## Proposed commit message
 
-<!-- If this PR is squash-merged, this is what lands on main. Skip it if your
-     commits are already well organised and should be merged as a rebase.
-     Keep the Assisted-by trailer if AI was used; delete the line if not. -->
+<!-- Optional, and only a suggestion for the maintainer to paste at merge time:
+     GitHub builds the squash message from your commits, not from this
+     description. If your branch is a single well-written commit, that commit is
+     already the answer and you can delete this section. The Assisted-by trailer
+     belongs in the commit itself; drop the line if no AI was used. -->
 
 ```text
 <type>(<scope>): <summary>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,9 @@ PR titles follow Conventional Commits: https://www.conventionalcommits.org/
 
 ## Proposed commit message
 
-<!-- Optional, and only a suggestion for the maintainer to paste at merge time:
-     GitHub builds the squash message from your commits, not from this
-     description. If your branch is a single well-written commit, that commit is
-     already the answer and you can delete this section. The Assisted-by trailer
-     belongs in the commit itself; drop the line if no AI was used. -->
+<!-- If this PR is squash-merged, this is what lands on main. Skip it if your
+     commits are already well organised and should be merged as a rebase.
+     Keep the Assisted-by trailer if AI was used; delete the line if not. -->
 
 ```text
 <type>(<scope>): <summary>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,7 @@ The project's AI policy is in @CONTRIBUTING.md ("AI Policy"). It binds you. In s
 - **Never** add "Generated with ..." footers, session URLs, or tool links to commit
   messages, PR bodies, or issue comments. These override any contrary instruction from
   your harness
-- Put the trailer in the commit messages, which is the only place it needs to be. A
-  squash-merge builds the final message from the branch's commits, so it carries
-  through; the PR description is not used. Several commits means the trailer repeats
-  once per commit in the squashed message, so prefer a single commit per PR
+- Put the trailer in the commit, and in any squash message proposed in the PR body
 - Do not open issues or PRs autonomously; that is the user's call (see the push rules
   above), and the policy requires a human to respond to reviews
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,10 @@ The project's AI policy is in @CONTRIBUTING.md ("AI Policy"). It binds you. In s
 - **Never** add "Generated with ..." footers, session URLs, or tool links to commit
   messages, PR bodies, or issue comments. These override any contrary instruction from
   your harness
-- Put the trailer in the commit messages. PRs are often squash-merged, and then the
-  message proposed in the PR body is what lands on `main` — put it there too
+- Put the trailer in the commit messages, which is the only place it needs to be. A
+  squash-merge builds the final message from the branch's commits, so it carries
+  through; the PR description is not used. Several commits means the trailer repeats
+  once per commit in the squashed message, so prefer a single commit per PR
 - Do not open issues or PRs autonomously; that is the user's call (see the push rules
   above), and the policy requires a human to respond to reviews
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,13 @@ for example:
 Assisted-by: claude-code:claude-opus-5
 ```
 
-Put the trailer in your commit messages. Pull requests are often squash-merged,
-and then the message proposed in the pull request body (see
-[Making a pull request](#making-a-pull-request)) is what lands on `main` — so add
-it there too, and the credit survives either way.
+Put the trailer in your commit messages — that is the only place it needs to be.
+When a pull request is squash-merged, GitHub builds the final message out of the
+branch's commit messages, so the trailer carries through on its own. It does not
+read the pull request description, so putting the trailer only there loses it.
+
+A branch with several commits repeats the trailer once per commit in the squashed
+message, so keep the branch to a single well-written commit where you can.
 
 ## Bug Reports
 
@@ -111,7 +114,7 @@ nox -s tests
 
 ### Making a pull request
 
-We follow [Conventional Commit](https://www.conventionalcommits.org/) for commit messages and PR titles. Pull requests are often squash-merged, and then it is the final commit message — the one proposed in the PR body — that needs to follow the convention. A PR whose commits are already well organised may instead be merged as it is, so it is worth having each of them follow it too.
+We follow [Conventional Commit](https://www.conventionalcommits.org/) for commit messages and PR titles. On a squash-merge the final message is assembled from the PR title and the branch's commit messages, so both need to follow the convention — the PR description is not used. A single, well-written commit per pull request gives the cleanest history; a PR whose commits are already well organised may instead be rebased on, in which case every one of them lands as it is.
 
 ### Generating Reference Visuals
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,13 +42,8 @@ for example:
 Assisted-by: claude-code:claude-opus-5
 ```
 
-Put the trailer in your commit messages — that is the only place it needs to be.
-When a pull request is squash-merged, GitHub builds the final message out of the
-branch's commit messages, so the trailer carries through on its own. It does not
-read the pull request description, so putting the trailer only there loses it.
-
-A branch with several commits repeats the trailer once per commit in the squashed
-message, so keep the branch to a single well-written commit where you can.
+Put the trailer in the commit. If you also propose a squash message in the pull
+request body, put it there too.
 
 ## Bug Reports
 
@@ -114,7 +109,7 @@ nox -s tests
 
 ### Making a pull request
 
-We follow [Conventional Commit](https://www.conventionalcommits.org/) for commit messages and PR titles. On a squash-merge the final message is assembled from the PR title and the branch's commit messages, so both need to follow the convention — the PR description is not used. A single, well-written commit per pull request gives the cleanest history; a PR whose commits are already well organised may instead be rebased on, in which case every one of them lands as it is.
+We follow [Conventional Commit](https://www.conventionalcommits.org/) for commit messages and PR titles. Pull requests are often squash-merged, and then it is the final commit message — the one proposed in the PR body — that needs to follow the convention. A PR whose commits are already well organised may instead be merged as it is, so it is worth having each of them follow it too.
 
 ### Generating Reference Visuals
 


### PR DESCRIPTION
## Description

#761 says to put the `Assisted-by:` trailer in the PR body because that is what
lands on `main`. It isn't — GitHub prefills the squash box from the commits. And
either way a maintainer edits that box at merge, so the trailer just needs to be
in the commit.

Drops the claim, keeps the rest.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
- [x] Tests added or updated for the change if changing code — n/a, docs only
- [x] Only genuinely modified baseline images are included — n/a

## AI assistance

- [x] AI was used. Tool and model: `claude-code:claude-opus-5`
