### PR TITLE
ci: bump build-and-inspect-python-package for metadata 2.5

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v3.0.1
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
   publish:
     needs: [dist]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2.18.0
+      - uses: hynek/build-and-inspect-python-package@v3.0.1
 
   publish:
     needs: [dist]


### PR DESCRIPTION
## Description

The `dist` job has been failing on every PR (e.g. #766, which is unrelated to the failure):

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

`hatchling` 1.32.0 (2026-08-11) started emitting `Metadata-Version: 2.5`.
`hynek/build-and-inspect-python-package@v2.18.0` pins `twine==6.2.0`, and twine
≤ 6.2 monkeypatches `packaging.metadata._VALID_METADATA_VERSIONS` to a
hardcoded list ending at `"2.4"` (`twine/package.py:32`), so it rejects the
wheel regardless of which `packaging` is installed.

Reproduced locally: building mplhep with current hatchling gives
`Metadata-Version: 2.5`; `twine==6.2.0` fails with exactly this error and
`twine==7.0.0` passes.

baipp v3.0.0 pins twine 7, whose release notes call this out by name
("Twine 7 that adds support for packaging metadata 2.5"). v3 is a major release
only because upstream stopped force-tagging `@v3`/`@v3.0` — no behavioural
change — so the full version tag is required.

## Proposed commit message

```text
ci: bump build-and-inspect-python-package for metadata 2.5

hatchling 1.32.0 started emitting `Metadata-Version: 2.5`, which twine
6.2.0 rejects: it monkeypatches
`packaging.metadata._VALID_METADATA_VERSIONS` to a hardcoded list that
stops at "2.4", so the check fails regardless of the installed
packaging.

build-and-inspect-python-package v3.0.0 pins twine 7, which knows about
metadata 2.5. v3 is a major only because upstream stopped force-tagging
`@v3`/`@v3.0`, so the full version tag is required.

Assisted-by: claude-code:claude-opus-5
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
- [x] Tests added or updated for the change if changing code — n/a, CI-only; the `dist` job on this PR is the test
- [x] Only genuinely modified baseline images are included — none

## AI assistance

- [x] AI was used. Tool and model: claude-code:claude-opus-5
