### PR TITLE
Update DUNE plotting style figure size.

### DIFF
--- a/src/mplhep/styles/dune.py
+++ b/src/mplhep/styles/dune.py
@@ -27,7 +27,7 @@ DUNE1 = {
     "mathtext.cal": "TeX Gyre Heros",
     "mathtext.default": "regular",
     # Figure configuration
-    "figure.figsize": (10, 10),
+    "figure.figsize": (8, 6),
     "figure.facecolor": "white",
     "figure.dpi": 100,
     "figure.autolayout": True,


### PR DESCRIPTION
<!--
PR titles follow Conventional Commits: https://www.conventionalcommits.org/
-->

## Description
The current default in the DUNE plotting style (10, 10) is significantly larger than the rest of the styles in this library. Furthermore, per the [official dune style guideline](https://github.com/DUNE/dune_plot_style/blob/main/guidelines.md), `Use an axis length ratio of y/x between 0.7 and 0.75 unless other considerations prevail.`

I'm not sure if I need to update any example figures in the plot. Please let me know if this is the case.

Another unrelated concern about the DUNE plotting style is that the first color is black. While this is indeed the correct color in the official DUNE-recommended colorwheel, the guideline also states `Data should generally be indicated by black`, as is usual in other experiments. Currently no other styles have black as their first color. If a change is desirable, please let me know and I'm happy to add another change.

Thanks again for this super useful library!

## Proposed commit message

Update DUNE figsize in the DUNE Plotting style to (8, 6).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
- [ ] Tests added or updated for the change if changing code
- [ ] Only genuinely modified baseline images are included

## AI assistance

See the [AI Policy](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md#ai-policy). Pick one:

- [x] No AI was used, or only for translation/grammar.
- [ ] AI was used. Tool and model: <!-- e.g. claude-code:claude-opus-5 -->

  By checking this you confirm you have reviewed and understood every line, you
  will respond to review comments yourself, and the commit message credits the
  assistance with `Assisted-by: <harness>:<model>` — never `Co-authored-by:` or
  `Signed-off-by:`.
