### PR TITLE
fix(tests): keep benchmark fixture working on pytest main

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,12 +26,27 @@ def _has_latex():
     return True
 
 
+def _alias_private_nodeid(items):
+    """Expose ``item.nodeid`` under the old private name ``item._nodeid``.
+
+    pytest-benchmark 5.3.0 reads ``node._nodeid``, which pytest main replaced
+    with a structured id (pytest-dev/pytest#14758, unreleased as of 9.2.0.dev),
+    so the ``benchmark`` fixture errors at setup there. Drop this once
+    pytest-benchmark reads the public ``node.nodeid``.
+    """
+    for item in items:
+        if not hasattr(item, "_nodeid"):
+            item._nodeid = item.nodeid
+
+
 def pytest_collection_modifyitems(config, items):  # noqa: ARG001
     """Skip LaTeX tests if LaTeX is not installed.
 
     Set MPLHEP_REQUIRE_LATEX to fail instead. CI LaTeX sets it so that a broken
     texlive install cannot produce a green run by skipping the whole suite.
     """
+    _alias_private_nodeid(items)
+
     if _has_latex():
         return
 


### PR DESCRIPTION
## Description

The "HEAD of dependencies" workflow's `pytest` job (pytest installed from git main) has been red since 2026-09-07, e.g. [run 34317420644](https://github.com/scikit-hep/mplhep/actions/runs/34317420644):

```text
ERROR tests/test_basic.py::test_simple_benchmark - AttributeError: 'Function' object has no attribute '_nodeid'. Did you mean: 'nodeid'?
```

pytest main replaced the private `Node._nodeid` attribute with a structured id in [pytest-dev/pytest#14758](https://github.com/pytest-dev/pytest/pull/14758) (merged 2026-09-06, unreleased as of 9.2.0.dev). pytest-benchmark 5.3.0 still reads `node._nodeid` at `fixture.py:88` when constructing the `benchmark` fixture, and its master branch has not changed that yet. `--benchmark-disable` does not help because the attribute is read while the fixture object is built.

This aliases `item.nodeid` under the old private name in `pytest_collection_modifyitems`, guarded by `hasattr`, so it is a no-op on released pytest. A plain instance attribute is used rather than a class-level property because pytest-xdist assigns to `item._nodeid` for `loadgroup` scheduling. It can be dropped once pytest-benchmark reads the public `node.nodeid`.

Verified locally:
- pytest 9.2.0.dev293 (git main) + pytest-benchmark 5.3.0: `test_simple_benchmark` now passes; full suite matches CI (325 passed, 53 skipped).
- pytest 9.1.1 (released): full suite with `-n 4 --benchmark-disable` unchanged, and the benchmark test still passes with benchmarks enabled.

## Proposed commit message

```text
fix(tests): keep benchmark fixture working on pytest main

pytest main replaced the private ``Node._nodeid`` attribute with a
structured id (pytest-dev/pytest#14758, unreleased as of 9.2.0.dev).
pytest-benchmark 5.3.0 still reads ``node._nodeid`` when building the
``benchmark`` fixture, so ``test_simple_benchmark`` errors at setup in the
"HEAD of dependencies" workflow's pytest job. Passing ``--benchmark-disable``
does not help since the attribute is read while the fixture is constructed.

Alias ``item.nodeid`` under the old private name during collection until
pytest-benchmark reads the public attribute. A plain instance attribute is
used rather than a class property because pytest-xdist assigns to
``item._nodeid`` for group scheduling.

Assisted-by: claude-code:claude-fable-5-1
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
- [x] Tests added or updated for the change if changing code (test-infrastructure only; the existing `test_simple_benchmark` covers it)
- [x] Only genuinely modified baseline images are included (none touched)

## AI assistance

See the [AI Policy](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md#ai-policy). Pick one:

- [ ] No AI was used, or only for translation/grammar.
- [x] AI was used. Tool and model: claude-code:claude-fable-5-1

  By checking this you confirm you have reviewed and understood every line, you
  will respond to review comments yourself, and the commit message credits the
  assistance with `Assisted-by: <harness>:<model>` — never `Co-authored-by:` or
  `Signed-off-by:`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BbDFGQycfYKscL3rGQT4Ka)_