### PR TITLE
chore(lint): ignore CPY rules stabilised in ruff 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ ignore = [
   "ANN",      # Not fully typed
   "C9",       # Complexity
   "COM812",   # Trailing commas teach the formatter
+  "CPY",      # No copyright headers
   "D",        # Documentation
   "E402",     # Make examples more readable
   "E501",     # Line too long


### PR DESCRIPTION
## Description

Fix-up for #764 (the pre-commit.ci autoupdate to ruff v0.16.6), which fails the `pre-commit.ci - pr` status on `ruff-check` with `CPY001 Missing copyright notice at top of file` in 78 files.

Ruff 0.16 promoted flake8-copyright's `CPY001` out of preview. Because `pyproject.toml` uses `select = ["ALL"]`, the newly stable rule fires on every file without a licence header. This project does not use per-file copyright headers, so this PR adds `CPY` to the ignore list.

Verified locally on the #764 head with ruff 0.16.6: `ruff check` reports `All checks passed!` and `ruff format --check` reports `114 files already formatted`.

Note for reviewers: ruff 0.16 also formats Python fences in Markdown by default, which is why the bot's auto-fix commit in #764 reformatted eight files under `new_docs/`. That is harmless (the generated guides are gitignored and the Read the Docs preview builds), but if you would rather ruff leave the docs alone, `extend-exclude = ["*.md"]` under `[tool.ruff]` turns it off.

## Proposed commit message

```text
chore(lint): ignore CPY rules stabilised in ruff 0.16

ruff 0.16 promoted flake8-copyright's CPY001 (missing-copyright-notice)
out of preview, so with `select = ["ALL"]` it now flags every file that
lacks a licence header. The project does not use per-file copyright
headers, so ignore the whole group.

Assisted-by: claude-code:claude-fable-5-1
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md)
- [ ] Tests added or updated for the change if changing code (not applicable: lint configuration only)
- [x] Only genuinely modified baseline images are included (none touched)

## AI assistance

See the [AI Policy](https://github.com/scikit-hep/mplhep/blob/main/CONTRIBUTING.md#ai-policy). Pick one:

- [ ] No AI was used, or only for translation/grammar.
- [x] AI was used. Tool and model: claude-code:claude-fable-5-1

  By checking this you confirm you have reviewed and understood every line, you
  will respond to review comments yourself, and the commit message credits the
  assistance with `Assisted-by: <harness>:<model>` — never `Co-authored-by:` or
  `Signed-off-by:`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ChSEvPd8xUvUba2Q6XfZS)_